### PR TITLE
docs: add project documentation (PRD, ADRs, architecture, sprint back…

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ There is no free, unified platform that combines real-time flight tracking with 
 
 ## Tech Stack
 
-| Layer | Technology | Version |
-|---|---|---|
-| **Frontend** | React, TypeScript, Globe.gl, Vite | 18.x, 5.x |
-| **Backend** | Spring Boot, Java | 3.2.x, 17 |
-| **Database** | PostgreSQL, PostGIS | 16, 3.4 |
-| **Testing** | JUnit 5, Mockito, Jest, React Testing Library | — |
-| **CI/CD** | GitHub Actions | — |
-| **Infrastructure** | Docker Compose | — |
+| Layer              | Technology                                    | Version   |
+| ------------------ | --------------------------------------------- | --------- |
+| **Frontend**       | React, TypeScript, Globe.gl, Vite             | 18.x, 5.x |
+| **Backend**        | Spring Boot, Java                             | 3.2.x, 17 |
+| **Database**       | PostgreSQL, PostGIS                           | 16, 3.4   |
+| **Testing**        | JUnit 5, Mockito, Jest, React Testing Library | —         |
+| **CI/CD**          | GitHub Actions                                | —         |
+| **Infrastructure** | Docker Compose                                | —         |
 
 ## Architecture
 
@@ -56,7 +56,7 @@ For full details, see the [System Architecture Document](docs/Argus_Architecture
 
 ```bash
 # 1. Clone the repository
-git clone https://github.com/tony-olivares/argus.git
+git clone https://github.com/tonyolives/argus.git
 cd argus
 
 # 2. Configure environment
@@ -128,29 +128,29 @@ argus/
 
 Argus follows strict **Test-Driven Development (TDD)** — tests are written before implementation for all service-layer code and interactive frontend components. See [ADR-005](docs/Argus_ADRs_v1_0.md) for the full rationale and [CONTRIBUTING.md](CONTRIBUTING.md) for the TDD workflow.
 
-| Layer | Tool | Target Coverage |
-|---|---|---|
-| Backend unit tests | JUnit 5 + Mockito | >80% |
+| Layer                     | Tool                              | Target Coverage   |
+| ------------------------- | --------------------------------- | ----------------- |
+| Backend unit tests        | JUnit 5 + Mockito                 | >80%              |
 | Backend integration tests | Spring Boot Test + TestContainers | All API endpoints |
-| Frontend tests | Jest + React Testing Library | >70% |
+| Frontend tests            | Jest + React Testing Library      | >70%              |
 
 ## Documentation
 
-| Document | Description |
-|---|---|
-| [Product Requirements (PRD)](docs/Argus_PRD_v1_0.md) | Scope, user stories, success metrics |
-| [Architecture Decision Records](docs/Argus_ADRs_v1_0.md) | 8 technical decisions with rationale |
-| [System Architecture](docs/Argus_Architecture_v1_0.md) | Component design, data flows, API contracts |
-| [Sprint Backlog](docs/Argus_Sprint_Backlog_v1_0.md) | 36 tickets across 7 sprints |
-| [API Reference](http://localhost:8080/swagger-ui.html) | Auto-generated OpenAPI docs (run backend first) |
+| Document                                                 | Description                                     |
+| -------------------------------------------------------- | ----------------------------------------------- |
+| [Product Requirements (PRD)](docs/Argus_PRD_v1_0.md)     | Scope, user stories, success metrics            |
+| [Architecture Decision Records](docs/Argus_ADRs_v1_0.md) | 8 technical decisions with rationale            |
+| [System Architecture](docs/Argus_Architecture_v1_0.md)   | Component design, data flows, API contracts     |
+| [Sprint Backlog](docs/Argus_Sprint_Backlog_v1_0.md)      | 36 tickets across 7 sprints                     |
+| [API Reference](http://localhost:8080/swagger-ui.html)   | Auto-generated OpenAPI docs (run backend first) |
 
 ## Data Sources
 
-| Source | Purpose | Cost |
-|---|---|---|
-| [OpenSky Network](https://opensky-network.org/) | Live aircraft positions | Free |
-| [GDELT Event API](https://www.gdeltproject.org/) | Auto-detected global events | Free |
-| [GDELT DOC API](https://blog.gdeltproject.org/gdelt-doc-2-0-api-expanded/) | Related news articles | Free |
+| Source                                                                     | Purpose                     | Cost |
+| -------------------------------------------------------------------------- | --------------------------- | ---- |
+| [OpenSky Network](https://opensky-network.org/)                            | Live aircraft positions     | Free |
+| [GDELT Event API](https://www.gdeltproject.org/)                           | Auto-detected global events | Free |
+| [GDELT DOC API](https://blog.gdeltproject.org/gdelt-doc-2-0-api-expanded/) | Related news articles       | Free |
 
 ## License
 
@@ -162,4 +162,4 @@ This project is licensed under the MIT License — see the [LICENSE](LICENSE) fi
 
 ---
 
-*Named after Argus Panoptes, the hundred-eyed giant of Greek mythology who served as an ever-vigilant watchman.*
+_Named after Argus Panoptes, the hundred-eyed giant of Greek mythology who served as an ever-vigilant watchman._

--- a/docs/Argus_ADRs_v1_0.md
+++ b/docs/Argus_ADRs_v1_0.md
@@ -1,0 +1,510 @@
+# ARGUS
+
+**Real-Time Global OSINT Monitoring Platform**
+
+**Architecture Decision Records (ADRs)**
+
+Version 1.0 | March 2026
+
+8 Decisions Documented
+
+| | |
+|---|---|
+| **Document Owner** | Tony Olivares — Project Lead |
+| **Status** | Living Document |
+| **Last Updated** | March 24, 2026 |
+| **Format** | Michael Nygard ADR Template |
+
+---
+
+## Table of Contents
+
+- [Overview](#overview)
+- [ADR Index](#adr-index)
+- [ADR-001: Spring Boot for Backend Framework](#adr-001-spring-boot-for-backend-framework)
+- [ADR-002: Globe.gl for 3D Globe Visualization](#adr-002-globegl-for-3d-globe-visualization)
+- [ADR-003: PostgreSQL with PostGIS for Database](#adr-003-postgresql-with-postgis-for-database)
+- [ADR-004: GDELT for Automated Incident Detection](#adr-004-gdelt-for-automated-incident-detection)
+- [ADR-005: Test-Driven Development (TDD) Methodology](#adr-005-test-driven-development-tdd-methodology)
+- [ADR-006: OpenSky Network for Live Flight Data](#adr-006-opensky-network-for-live-flight-data)
+- [ADR-007: Polling Over WebSockets for MVP Data Updates](#adr-007-polling-over-websockets-for-mvp-data-updates)
+- [ADR-008: GDELT DOC API for News Article Retrieval](#adr-008-gdelt-doc-api-for-news-article-retrieval)
+
+---
+
+## Overview
+
+Architecture Decision Records (ADRs) capture significant technical decisions made during the development of Argus. Each ADR follows a standardized template inspired by Michael Nygard's lightweight ADR format, documenting the context that prompted the decision, the options that were evaluated, the final decision and its rationale, and the consequences (both positive and negative) that follow.
+
+ADRs are immutable once accepted. If a decision is later reversed, the original ADR is marked as "Superseded" and a new ADR is created referencing it. This preserves the decision history and makes it easy to understand why the architecture evolved.
+
+## ADR Index
+
+| ID | Title | Status | Date |
+|---|---|---|---|
+| **ADR-001** | Spring Boot for Backend Framework | **Accepted** | Mar 24, 2026 |
+| **ADR-002** | Globe.gl for 3D Globe Visualization | **Accepted** | Mar 24, 2026 |
+| **ADR-003** | PostgreSQL with PostGIS for Database | **Accepted** | Mar 24, 2026 |
+| **ADR-004** | GDELT for Automated Incident Detection | **Accepted** | Mar 24, 2026 |
+| **ADR-005** | Test-Driven Development (TDD) Methodology | **Accepted** | Mar 24, 2026 |
+| **ADR-006** | OpenSky Network for Live Flight Data | **Accepted** | Mar 24, 2026 |
+| **ADR-007** | Polling Over WebSockets for MVP Data Updates | **Accepted** | Mar 24, 2026 |
+| **ADR-008** | GDELT DOC API for News Article Retrieval | **Accepted** | Mar 24, 2026 |
+
+---
+
+## ADR-001: Spring Boot for Backend Framework
+
+| | |
+|---|---|
+| **Status** | **Accepted** |
+| **Date** | March 24, 2026 |
+| **Decision Maker** | Tony Olivares |
+| **Relates To** | PRD Section 7.2 — Tech Stack Justifications |
+
+### Context
+
+Argus requires a backend service that aggregates data from multiple external APIs (OpenSky, GDELT), applies business logic (filtering, transformation, caching), exposes a RESTful API to the frontend, and runs scheduled polling tasks. The backend must be well-tested, maintainable, and demonstrate production-grade engineering practices.
+
+The primary candidates are Spring Boot (Java) and Express.js (Node.js). Both are mature, well-documented, and widely used in production. The decision should consider development velocity, testing ecosystem, resume signal, and long-term scalability.
+
+### Options Considered
+
+| Option | Pros | Cons |
+|---|---|---|
+| **Spring Boot 3 (Java 17+)** | + Strong typing catches bugs at compile time | - More verbose than Node.js for simple tasks |
+| | + Mature testing ecosystem (JUnit 5, Mockito, TestContainers) | - Slower initial development for prototyping |
+| | + Built-in scheduling (@Scheduled) for polling tasks | - Heavier resource footprint than Node.js |
+| | + Swagger/OpenAPI auto-generation from annotations | - Requires JDK setup and build tool (Maven/Gradle) |
+| | + Strong resume signal for enterprise and defense companies | |
+| | + Excellent dependency injection and separation of concerns | |
+| **Express.js (Node.js)** | + Faster prototyping with less boilerplate | - Dynamic typing increases runtime bug risk |
+| | + Same language (JavaScript) as the React frontend | - Testing ecosystem is less structured |
+| | + Lightweight and low resource footprint | - Scheduling requires third-party libraries (node-cron) |
+| | + Large npm ecosystem for quick integrations | - Weaker resume signal for enterprise/defense roles |
+| | | - Callback patterns can complicate error handling at scale |
+
+### Decision
+
+We will use **Spring Boot 3 with Java 17+** as the backend framework.
+
+The deciding factors are: (1) the project owner is already actively building with Spring Boot, eliminating ramp-up time; (2) the testing ecosystem (JUnit 5 + Mockito + TestContainers) is best-in-class for TDD, which is a core project requirement; (3) Spring Boot's enterprise credibility is a strategic advantage for the target job market (defense, fintech, enterprise SaaS); and (4) built-in scheduling and structured dependency injection are well-suited to the polling-heavy architecture.
+
+The additional verbosity is an acceptable tradeoff given the benefits in testability and type safety.
+
+### Consequences
+
+- Backend will be built with Spring Boot 3.2+, Java 17, and Gradle as the build tool.
+- All external API integrations will use RestTemplate or WebClient with Mockito-based mocking in tests.
+- Scheduled tasks will use Spring's `@Scheduled` annotation with configurable intervals.
+- API documentation will be auto-generated via springdoc-openapi (Swagger UI).
+- Developers must have JDK 17+ and Gradle installed locally.
+
+### References
+
+- [Spring Boot 3 Documentation](https://docs.spring.io/spring-boot/docs/current/reference/html/)
+- [JUnit 5 User Guide](https://junit.org/junit5/docs/current/user-guide/)
+
+---
+
+## ADR-002: Globe.gl for 3D Globe Visualization
+
+| | |
+|---|---|
+| **Status** | **Accepted** |
+| **Date** | March 24, 2026 |
+| **Decision Maker** | Tony Olivares |
+| **Relates To** | PRD Section 7.2 — Tech Stack Justifications |
+
+### Context
+
+The core visual element of Argus is an interactive 3D globe showing live flights and geopolitical incidents. The visualization library must support: rendering thousands of point markers (flights) with smooth updates, custom HTML or icon markers for categorized incidents, arc rendering for flight paths, click interactions for detail panels, smooth rotation/zoom/pan, and a dark professional aesthetic.
+
+Three primary options were evaluated: Cesium.js (full geospatial platform), Globe.gl (Three.js-based globe), and Mapbox GL / Leaflet (2D map projections).
+
+### Options Considered
+
+| Option | Pros | Cons |
+|---|---|---|
+| **Globe.gl** | + Simple declarative API — globe with points in ~50 lines | - Not a true GIS tool — no terrain, no map tiles |
+| | + Built on Three.js, excellent rendering performance | - Less mature ecosystem than Cesium or Mapbox |
+| | + Native support for points, arcs, custom HTML markers, hex bins | - Custom marker styling requires HTML overlay workarounds |
+| | + Stunning visual aesthetic out of the box (dark globe) | - No built-in geocoding or routing |
+| | + Active maintenance, good documentation | |
+| | + Low learning curve — fastest time to impressive visual output | |
+| **Cesium.js** | + Full 3D geospatial platform with terrain, imagery, and 3D tiles | - Massive learning curve — weeks to configure properly |
+| | + Military/defense industry standard (used by Palantir) | - Heavy bundle size (~10MB+) impacts load time |
+| | + Extremely powerful for GIS applications | - Requires Cesium Ion account for imagery |
+| | + Time-dynamic visualization built in | - Vastly over-engineered for MVP requirements |
+| **Mapbox GL / Leaflet** | + Mature 2D mapping with rich tile layers | - 2D projection lacks the visual impact of a 3D globe |
+| | + Excellent documentation and community | - Does not match the Palantir Maven aesthetic |
+| | + Good performance for marker clustering | - Globe mode in Mapbox is limited and requires paid tier |
+| | + Familiar to most web developers | - Less visually impressive for portfolio/demo purposes |
+
+### Decision
+
+We will use **Globe.gl** as the primary visualization library.
+
+Globe.gl offers the highest ratio of visual impact to development complexity. For an MVP focused on demonstrating full-stack capability and creating a striking visual demo, Globe.gl is the clear winner. It produces the dark, professional globe aesthetic that immediately evokes Palantir Maven, while requiring a fraction of the development time that Cesium would demand.
+
+Cesium remains a viable upgrade path for post-MVP if true GIS capabilities (terrain analysis, 3D building models, military-grade mapping) become requirements. The migration path is documented but not planned.
+
+### Consequences
+
+- Frontend will use `react-globe.gl` (React wrapper for Globe.gl) as the primary visualization component.
+- Flight positions will be rendered as point markers with custom plane icons using the `htmlElementsData` layer.
+- Incidents will be rendered as colored HTML markers with category-specific icons.
+- Flight arcs (origin to destination) are deferred to post-MVP but supported natively by Globe.gl.
+- True GIS features (terrain, satellite imagery, street-level detail) are not available and are explicitly out of scope for MVP.
+- Three.js knowledge will be beneficial for custom visual effects but not required for core functionality.
+
+### References
+
+- [Globe.gl Documentation](https://globe.gl/)
+- [react-globe.gl](https://github.com/vasturiano/react-globe.gl)
+- [Cesium.js](https://cesium.com/platform/cesiumjs/)
+
+---
+
+## ADR-003: PostgreSQL with PostGIS for Database
+
+| | |
+|---|---|
+| **Status** | **Accepted** |
+| **Date** | March 24, 2026 |
+| **Decision Maker** | Tony Olivares |
+| **Relates To** | PRD Section 7.1 — System Overview |
+
+### Context
+
+Argus needs persistent storage for cached flight positions, detected incidents, and fetched news articles. The database must handle concurrent writes (polling tasks inserting data) alongside concurrent reads (frontend API requests). Additionally, the data is inherently geospatial — every flight and incident has latitude/longitude coordinates, and future features will require spatial queries (e.g., "find all incidents within 500km of this point").
+
+The project owner initially considered SQLite for simplicity. This ADR evaluates whether SQLite, PostgreSQL, or an alternative better serves the project's needs.
+
+### Options Considered
+
+| Option | Pros | Cons |
+|---|---|---|
+| **PostgreSQL 16 + PostGIS** | + Native geospatial queries via PostGIS extension | - Requires running a separate database process |
+| | + Excellent concurrent read/write handling | - Slightly more setup than file-based SQLite |
+| | + Production-grade — same DB used in deployment | - Heavier resource usage for a local dev machine |
+| | + Rich indexing (B-tree, GiST for spatial, GIN for full-text) | |
+| | + Spring Data JPA has excellent PostgreSQL support | |
+| | + Free and open source with massive community | |
+| | + Strong resume signal | |
+| **SQLite** | + Zero configuration — single file database | - Poor concurrent write support (single-writer lock) |
+| | + No separate process needed | - No native geospatial extension |
+| | + Extremely lightweight | - Not suitable for production deployment |
+| | + Good for simple prototypes | - Would require migration to PostgreSQL later |
+| | | - Limited Spring Data JPA dialect support |
+| **MongoDB** | + Flexible schema for varied event data | - Overkill for this data model which is fairly relational |
+| | + Built-in geospatial queries ($geoNear, $geoWithin) | - Additional technology to learn and maintain |
+| | + Good for document-oriented data like news articles | - Weaker fit with Spring Data JPA patterns |
+| | | - Less resume signal for enterprise Java roles |
+
+### Decision
+
+We will use **PostgreSQL 16 with the PostGIS extension**.
+
+The deciding factors are: (1) PostGIS provides native geospatial indexing and queries that directly support the core use case; (2) PostgreSQL handles concurrent reads and writes gracefully, which is critical since polling tasks write data continuously while the API serves reads; (3) using PostgreSQL from day one avoids a painful SQLite-to-Postgres migration later; and (4) PostgreSQL is the industry standard for production Java applications.
+
+Docker will be used to run PostgreSQL locally, ensuring consistent setup across environments and simplifying the developer onboarding experience.
+
+### Consequences
+
+- PostgreSQL 16 will run via Docker Compose for local development.
+- PostGIS extension will be enabled for geospatial column types and spatial indexing.
+- Spring Data JPA with Hibernate Spatial will be used for geospatial entity mapping.
+- Database schema migrations will be managed by Flyway.
+- A `docker-compose.yml` will be provided in the repository for one-command database setup.
+- Developers must have Docker installed locally.
+
+### References
+
+- [PostGIS Documentation](https://postgis.net/documentation/)
+- [Hibernate Spatial](https://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#spatial)
+- [Flyway Migrations](https://flywaydb.org/documentation/)
+
+---
+
+## ADR-004: GDELT for Automated Incident Detection
+
+| | |
+|---|---|
+| **Status** | **Accepted** |
+| **Date** | March 24, 2026 |
+| **Decision Maker** | Tony Olivares |
+| **Relates To** | PRD Section 8 — Data Sources |
+
+### Context
+
+A core differentiator of Argus is automated detection of global incidents (conflicts, disasters, political crises, infrastructure outages) displayed on the globe. This requires a data source that: provides global event coverage in near-real-time, includes geolocation data (lat/lng), categorizes events by type and severity, is free and does not require a commercial license, and is reliable enough for continuous polling.
+
+The alternatives range from fully manual curation to automated feeds from conflict databases and news monitoring platforms.
+
+### Options Considered
+
+| Option | Pros | Cons |
+|---|---|---|
+| **GDELT** | + Completely free with no rate limits | - High noise ratio — requires aggressive filtering |
+| | + Global coverage — monitors news in 100+ languages | - Geocoding is approximate (city/country level) |
+| | + Events are geocoded (lat/lng) automatically | - Event deduplication is imperfect |
+| | + Goldstein Scale provides severity scoring (-10 to +10) | - Data quality varies by region and language |
+| | + CAMEO event codes provide granular categorization | - No real-time streaming — polling only |
+| | + Updated every 15 minutes | |
+| | + DOC API provides related news articles for free | |
+| | + Academic and OSINT communities actively use it | |
+| **ACLED** | + High-quality, human-curated conflict data | - Requires registration and has usage restrictions |
+| | + Precise geolocation and categorization | - Focused only on conflict — misses disasters, political events |
+| | + Academic gold standard for conflict research | - Delayed updates (not real-time or near-real-time) |
+| | | - API access may require academic affiliation |
+| **Manual Curation** | + Complete control over quality and relevance | - Does not scale — requires constant human attention |
+| | + No API dependency or noise filtering needed | - Defeats the purpose of an automated monitoring platform |
+| | + Can include nuanced events that automated systems miss | - Not impressive from an engineering perspective |
+
+### Decision
+
+We will use **GDELT** as the primary incident detection data source, with aggressive server-side filtering to manage noise.
+
+GDELT is uniquely positioned for Argus because it combines event detection, geocoding, severity scoring, and news article retrieval in a single free platform. No other free source provides this combination. The noise problem is real but solvable through engineering — and the filtering logic itself becomes a strong technical talking point.
+
+The filtering strategy will use a multi-layer approach: (1) Goldstein Scale threshold to exclude low-impact events, (2) CAMEO code allowlist to focus on relevant categories (armed conflict, protests, disasters, sanctions, infrastructure disruption), (3) geographic deduplication to cluster nearby events, and (4) recency filter to show only events from the last 24–48 hours.
+
+### Consequences
+
+- A scheduled Spring service will poll the GDELT Event API every 15–30 minutes.
+- Raw events will be filtered through a configurable multi-layer pipeline before storage.
+- The GDELT DOC API will be used on-demand to fetch related news articles when a user clicks an incident.
+- Incident categories will map CAMEO codes to user-friendly labels: Conflict, Disaster, Political, Infrastructure.
+- Filter thresholds will be configurable via application properties to allow tuning without code changes.
+- A fallback set of curated seed incidents will be available for demos if GDELT is temporarily unavailable.
+- ACLED remains a potential supplementary source for post-MVP if conflict-specific precision is needed.
+
+### References
+
+- [GDELT Project](https://www.gdeltproject.org/)
+- [GDELT Event API](https://blog.gdeltproject.org/gdelt-2-0-our-global-world-in-realtime/)
+- [GDELT DOC API](https://blog.gdeltproject.org/gdelt-doc-2-0-api-expanded/)
+- [CAMEO Event Codes](https://eventdata.parusanalytics.com/data.dir/cameo.html)
+
+---
+
+## ADR-005: Test-Driven Development (TDD) Methodology
+
+| | |
+|---|---|
+| **Status** | **Accepted** |
+| **Date** | March 24, 2026 |
+| **Decision Maker** | Tony Olivares |
+| **Relates To** | PRD Section 9 — Testing Strategy |
+
+### Context
+
+Argus is both a functional product and a portfolio piece intended to demonstrate production-grade engineering practices to potential employers. Testing methodology is a key differentiator — most portfolio projects have minimal or no tests. The project must balance development velocity (ship fast) with code quality (ship clean).
+
+Three testing approaches were considered, ranging from full TDD to minimal post-hoc testing.
+
+### Options Considered
+
+| Option | Pros | Cons |
+|---|---|---|
+| **Full TDD (Red-Green-Refactor)** | + Forces clear API design before implementation | - 20–30% slower initial development velocity |
+| | + Catches bugs at the earliest possible stage | - Can feel rigid when exploring unfamiliar APIs |
+| | + Produces naturally testable, decoupled code | - Risk of testing trivial code (over-testing) |
+| | + Test suite serves as living documentation | - Requires discipline to maintain when under time pressure |
+| | + Extremely impressive in portfolio context | |
+| | + Builds confidence in refactoring | |
+| **Test Critical Paths Only** | + Faster development than full TDD | - Ambiguity about what qualifies as "critical" |
+| | + Focuses testing effort where it matters most | - Easy to rationalize skipping tests under time pressure |
+| | + Good balance of speed and quality | - Less impressive as a portfolio artifact |
+| | | - Gaps in coverage may hide bugs |
+| **Minimal Testing (Post-Implementation)** | + Maximum initial velocity | - Tests rarely get written retroactively |
+| | + No upfront time investment in test infrastructure | - No portfolio differentiation |
+| | | - Technical debt accumulates rapidly |
+| | | - Refactoring becomes risky without safety net |
+
+### Decision
+
+We will follow **full TDD (Red-Green-Refactor)** for all backend service-layer code and all interactive frontend components.
+
+To avoid the over-testing trap, the following are explicitly excluded from TDD requirements: Spring configuration classes, simple DTOs and entity classes with no logic, basic component rendering (e.g., a paragraph displays text), and build/deployment scripts.
+
+The pragmatic approach: write tests first for anything that transforms, filters, processes, or makes decisions. Skip tests for anything that is purely structural or declarative.
+
+### Consequences
+
+- Every service class will have a corresponding test class written before the implementation.
+- Backend tests will use JUnit 5 for assertions and Mockito for mocking external dependencies.
+- Frontend tests will use Jest with React Testing Library, focused on user interaction flows.
+- Code coverage will be tracked via JaCoCo (backend, target >80%) and Jest coverage (frontend, target >70%).
+- Pull requests must include tests. PRs without tests for non-trivial code will not be merged.
+- CI pipeline (GitHub Actions) will run the full test suite on every push.
+- Initial velocity will be slower, but code quality and refactoring confidence will compound over time.
+
+### References
+
+- Kent Beck, *Test-Driven Development: By Example* (Addison-Wesley, 2002)
+- [Martin Fowler on TDD](https://martinfowler.com/bliki/TestDrivenDevelopment.html)
+- [JUnit 5 + Mockito Guide](https://www.baeldung.com/mockito-junit-5-extension)
+
+---
+
+## ADR-006: OpenSky Network for Live Flight Data
+
+| | |
+|---|---|
+| **Status** | **Accepted** |
+| **Date** | March 24, 2026 |
+| **Decision Maker** | Tony Olivares |
+| **Relates To** | PRD Section 8 — Data Sources |
+
+### Context
+
+Argus requires live aircraft position data to render flights on the globe. The data must include at minimum: geographic position (lat/lng), altitude, velocity, heading, and an aircraft identifier (callsign or transponder code). The data source must be free for non-commercial use.
+
+Several flight tracking data providers offer APIs with varying levels of access, cost, and data quality.
+
+### Options Considered
+
+| Option | Pros | Cons |
+|---|---|---|
+| **OpenSky Network** | + Completely free — no API key required for anonymous access | - Anonymous rate limit is ~100 requests/day |
+| | + Returns all airborne aircraft globally in a single request | - Coverage gaps in regions with sparse ADS-B receivers |
+| | + Provides position, altitude, velocity, heading, callsign, ICAO24, origin country | - No aircraft model or route information |
+| | + Free registered account increases rate limit to ~4000 requests/day | - Data freshness limited to ~10 seconds at best |
+| | + Open source and community-driven | |
+| | + No commercial license restrictions for non-redistribution use | |
+| **ADS-B Exchange** | + Comprehensive global coverage including military aircraft | - API access requires a paid subscription ($10+/month) |
+| | + Real-time data with minimal delay | - Rate limits on free tier are very restrictive |
+| | + Community-maintained with strong OSINT following | - Terms of service restrict commercial use |
+| **FlightAware / FlightRadar24** | + Rich data including aircraft model, route, airline info | - Paid APIs — free tiers are extremely limited |
+| | + Excellent coverage and data quality | - Commercial licenses required for any data display |
+| | + Well-documented commercial APIs | - Expensive at scale ($100s–$1000s/month) |
+| | | - Terms prohibit displaying data in competing products |
+
+### Decision
+
+We will use **OpenSky Network** as the sole flight data provider for MVP.
+
+OpenSky is the only provider that is truly free and provides sufficient data for a compelling globe visualization. The limitations (no aircraft model, coverage gaps, rate limits) are acceptable for an MVP. A free registered account will be created to increase the rate limit to 4000 requests/day, which is more than sufficient for a 15–30 second polling interval.
+
+The backend will cache flight data in PostgreSQL with a configurable TTL, reducing the number of API calls while keeping the globe reasonably current.
+
+### Consequences
+
+- A free OpenSky Network account will be created and credentials stored in application properties (not committed to git).
+- Flight data will be polled every 15–30 seconds via the `/states/all` REST endpoint.
+- Aircraft detail is limited to what OpenSky provides: ICAO24, callsign, origin country, position, altitude, velocity, heading, vertical rate, and on-ground status.
+- Aircraft model, airline name, and route information are not available and are out of scope for MVP.
+- A mock data generator will be created for testing and demo scenarios when API limits are reached.
+- Post-MVP: enrichment from a secondary source (e.g., a static aircraft database mapping ICAO24 to aircraft type) may be added.
+
+### References
+
+- [OpenSky Network API](https://openskynetwork.github.io/opensky-api/)
+- [OpenSky REST API States](https://openskynetwork.github.io/opensky-api/rest.html)
+
+---
+
+## ADR-007: Polling Over WebSockets for MVP Data Updates
+
+| | |
+|---|---|
+| **Status** | **Accepted** |
+| **Date** | March 24, 2026 |
+| **Decision Maker** | Tony Olivares |
+| **Relates To** | PRD Section 5.2 — Explicitly Out of Scope |
+
+### Context
+
+Argus needs to keep the globe updated with fresh flight and incident data. Two primary patterns exist for delivering updates from server to client: HTTP polling (client requests data at intervals) and WebSocket streaming (server pushes data as it arrives). The choice impacts architecture complexity, real-time responsiveness, and development time.
+
+### Options Considered
+
+| Option | Pros | Cons |
+|---|---|---|
+| **HTTP Polling** | + Trivially simple to implement (setInterval + fetch) | - Slight delay between data availability and display |
+| | + Works with standard REST endpoints — no new infrastructure | - Redundant requests when data hasn't changed |
+| | + Easy to test, debug, and monitor | - Higher cumulative bandwidth for high-frequency updates |
+| | + Frontend controls update frequency | |
+| | + Stateless — no connection management needed | |
+| | + Perfectly adequate for 10–30 second update intervals | |
+| **WebSocket Streaming** | + True real-time — sub-second push from server to client | - Significant additional complexity |
+| | + Efficient for high-frequency updates | - Requires Spring WebSocket configuration and STOMP protocol |
+| | + Lower cumulative bandwidth for rapidly changing data | - Harder to test and debug than simple REST calls |
+| | | - Overkill when source data updates every 10–30 seconds anyway |
+| | | - Additional frontend state management for socket lifecycle |
+
+### Decision
+
+We will use **HTTP polling** for all data updates in MVP.
+
+Since the upstream data sources themselves update every 10–30 seconds (OpenSky) and 15–30 minutes (GDELT), WebSocket streaming provides no user-visible benefit. The data simply does not change fast enough to justify the architectural complexity. Polling is simpler to build, test, and debug, and allows the MVP to ship faster.
+
+WebSocket streaming is explicitly deferred to v2.0 as documented in the product roadmap, to be considered when (and if) sub-second updates become a real requirement.
+
+### Consequences
+
+- Frontend will use `setInterval` or React Query's `refetchInterval` to poll the Argus API.
+- Flight data polling interval: 15–30 seconds (configurable).
+- Incident data polling interval: 5–10 minutes (configurable, since GDELT updates every 15 minutes).
+- No WebSocket dependencies will be added to either frontend or backend.
+- The polling architecture is simple enough that it can be replaced with WebSockets later without major refactoring.
+
+---
+
+## ADR-008: GDELT DOC API for News Article Retrieval
+
+| | |
+|---|---|
+| **Status** | **Accepted** |
+| **Date** | March 24, 2026 |
+| **Decision Maker** | Tony Olivares |
+| **Relates To** | PRD Section 5.1 — News Integration |
+
+### Context
+
+When a user clicks on an incident on the Argus globe, the detail panel should display related news articles to provide context and allow the user to investigate further. This requires a news retrieval API that can search for articles by topic, location, or keywords, and return headlines, sources, timestamps, and links.
+
+Since Argus already uses GDELT for incident detection, the question is whether to also use GDELT's DOC API for news retrieval or to integrate a separate news API.
+
+### Options Considered
+
+| Option | Pros | Cons |
+|---|---|---|
+| **GDELT DOC API** | + Already integrated — same platform as incident detection | - Article selection biased toward GDELT's crawlers |
+| | + Completely free with no rate limits | - No paywall bypass — some linked articles may be behind paywalls |
+| | + Returns articles with title, source, URL, date, tone, and language | - Less polished metadata than dedicated news APIs |
+| | + Can search by keyword, theme, location, and time range | - Search quality varies for niche or non-English events |
+| | + Keeps architecture simple (one external dependency instead of two) | |
+| | + Articles are directly related to the same events GDELT detected | |
+| **NewsAPI.org** | + Clean, well-documented REST API | - Free tier limited to 100 requests/day |
+| | + Good coverage of major English-language sources | - Free tier is for development only — cannot be used in production |
+| | + Returns thumbnails and descriptions | - Requires a separate API key and integration |
+| | | - Adds a second external dependency to manage |
+| **GNews API** | + Free tier with 100 requests/day | - Free tier rate limit is restrictive |
+| | + Simple keyword search API | - Less granular search (no location or theme filtering) |
+| | + Returns title, description, URL, source, and image | - Adds a second external dependency |
+| | | - May not find relevant articles for non-headline events |
+
+### Decision
+
+We will use **GDELT DOC API** as the sole news retrieval source for MVP.
+
+The architectural simplicity of using a single external platform (GDELT) for both incident detection and news retrieval is the primary driver. The DOC API is free, unlimited, and already semantically connected to the events we are displaying — meaning search results are naturally relevant without complex query construction.
+
+The on-demand query pattern (fetch news only when a user clicks an incident) keeps API usage efficient and avoids unnecessary caching complexity.
+
+### Consequences
+
+- News articles will be fetched on-demand via the GDELT DOC API when a user clicks an incident.
+- Search queries will be constructed from incident metadata: event description, actor names, and geographic location.
+- Results will be displayed in the incident detail panel with headline, source name, publication date, and link to original article.
+- Article results will be cached in PostgreSQL with a 1-hour TTL to avoid redundant API calls.
+- No separate news API key or account is required.
+- Post-MVP: a secondary news source (NewsAPI, GNews) may be added to improve coverage and provide fallback.
+
+### References
+
+- [GDELT DOC API Documentation](https://blog.gdeltproject.org/gdelt-doc-2-0-api-expanded/)
+- [GDELT DOC API Query Format](https://api.gdeltproject.org/api/v2/doc/doc?query=example&mode=artlist)

--- a/docs/Argus_Architecture_v1_0.md
+++ b/docs/Argus_Architecture_v1_0.md
@@ -1,0 +1,271 @@
+# ARGUS
+
+**Real-Time Global OSINT Monitoring Platform**
+
+**System Architecture Document**
+
+Version 1.0 | March 2026
+
+| | |
+|---|---|
+| **Document Owner** | Tony Olivares — Project Lead |
+| **Status** | Draft |
+| **Last Updated** | March 24, 2026 |
+| **Related Docs** | PRD v1.0, ADRs v1.0 |
+
+---
+
+## Table of Contents
+
+- [1. Architecture Overview](#1-architecture-overview)
+- [2. System Topology](#2-system-topology)
+- [3. Component Architecture](#3-component-architecture)
+- [4. Data Flow Patterns](#4-data-flow-patterns)
+- [5. REST API Contracts](#5-rest-api-contracts)
+- [6. Infrastructure and DevOps](#6-infrastructure-and-devops)
+- [7. Cross-Cutting Concerns](#7-cross-cutting-concerns)
+- [8. Future Architecture Considerations](#8-future-architecture-considerations)
+- [9. Diagram Reference](#9-diagram-reference)
+
+---
+
+## 1. Architecture Overview
+
+Argus uses a three-tier architecture with a React single-page application (SPA) as the presentation layer, a Spring Boot REST API as the application layer, and PostgreSQL with PostGIS as the data layer. The system aggregates data from external APIs through scheduled polling, processes and caches it server-side, and serves it to the frontend via a documented REST API.
+
+This document describes the system topology, component responsibilities, data flow patterns, database schema, API contracts, and infrastructure configuration. It should be read alongside the [PRD](Argus_PRD_v1_0.md) (product requirements) and [ADRs](Argus_ADRs_v1_0.md) (technical decisions).
+
+## 2. System Topology
+
+The following table summarizes all runtime components and their responsibilities:
+
+| Component | Technology | Responsibility | Port / Access |
+|---|---|---|---|
+| **Frontend SPA** | React 18, Globe.gl, Vite | 3D globe rendering, user interactions, state management, polling orchestration | localhost:5173 (Vite dev) |
+| **Backend API** | Spring Boot 3.2, Java 17, Maven | REST API, scheduled polling, data aggregation, business logic, caching | localhost:8080 |
+| **Database** | PostgreSQL 16, PostGIS 3.4 | Persistent storage, geospatial indexing, full-text search | localhost:5432 |
+| **OpenSky API** | External REST API | Live aircraft position data (ICAO24, callsign, lat/lng, altitude, velocity) | opensky-network.org |
+| **GDELT Event API** | External REST API | Auto-detected global events with geocoding and severity scoring | api.gdeltproject.org |
+| **GDELT DOC API** | External REST API | News article retrieval by keyword, theme, location | api.gdeltproject.org |
+
+## 3. Component Architecture
+
+### 3.1 Frontend (React + Globe.gl)
+
+The frontend is a React 18 single-page application built with Vite. The primary visual component is a Globe.gl instance rendered via the `react-globe.gl` wrapper. The frontend is responsible for:
+
+- Rendering the interactive 3D globe with flight markers and incident indicators.
+- Polling the Argus REST API at configurable intervals for updated data.
+- Managing UI state: selected flight/incident, active filters, panel visibility.
+- Rendering detail panels when a user clicks a flight or incident marker.
+- Fetching related news articles on demand when an incident is selected.
+
+**Key libraries:** `react-globe.gl` (globe rendering), React Query or SWR (data fetching and cache), React Testing Library + Jest (testing).
+
+**Directory structure (planned):**
+
+```
+frontend/src/
+├── components/    # Globe, FlightPanel, IncidentPanel, FilterBar
+├── hooks/         # useFlights, useIncidents, useNews
+├── services/      # API client functions
+├── types/         # TypeScript interfaces for API response models
+└── __tests__/     # Jest + RTL test files
+```
+
+### 3.2 Backend (Spring Boot 3)
+
+The backend is a Spring Boot 3.2 application running on Java 17. It serves three purposes: aggregating data from external APIs via scheduled polling, applying business logic (filtering, transformation, caching), and exposing a RESTful API for the frontend.
+
+#### 3.2.1 Package structure
+
+| Package | Responsibility |
+|---|---|
+| `com.argus.controller` | REST controllers exposing `/api/v1/*` endpoints. Thin layer — delegates to services. |
+| `com.argus.service` | Core business logic: FlightService, IncidentService, NewsService. All TDD-tested. |
+| `com.argus.service.poller` | Scheduled tasks: FlightPollerService, IncidentPollerService. `@Scheduled` with configurable intervals. |
+| `com.argus.service.filter` | IncidentFilterPipeline: multi-stage filtering (Goldstein threshold, CAMEO allowlist, dedup, recency). |
+| `com.argus.repository` | Spring Data JPA repositories with custom PostGIS queries. |
+| `com.argus.model` | JPA entities: Flight, Incident, NewsArticle. Hibernate Spatial for geometry columns. |
+| `com.argus.dto` | Data Transfer Objects for API responses. Decoupled from entities. |
+| `com.argus.config` | Spring configuration: RestTemplate beans, CORS, scheduling, Swagger/OpenAPI. |
+| `com.argus.client` | External API clients: OpenSkyClient, GdeltEventClient, GdeltDocClient. Mockable for tests. |
+
+#### 3.2.2 Scheduled polling architecture
+
+Two independent pollers run as Spring `@Scheduled` tasks:
+
+| Poller | Interval | Source | Behavior |
+|---|---|---|---|
+| **FlightPollerService** | 15-30 seconds | OpenSky `/states/all` | Fetches all airborne aircraft globally. Upserts into flights table by ICAO24 address. Stale flights (not seen in 5 min) are marked inactive. |
+| **IncidentPollerService** | 15-30 minutes | GDELT Event API v2 | Fetches events from last 24h. Pipes through IncidentFilterPipeline. Inserts new incidents, deduplicates against existing by location + type + time window. |
+
+#### 3.2.3 Incident filter pipeline
+
+The IncidentFilterPipeline is the most critical piece of business logic. It transforms thousands of raw GDELT events into 10-30 meaningful incidents displayed on the globe. The pipeline consists of four stages executed in order:
+
+1. **Goldstein Scale filter** — Removes events with severity between -3 and +3 (low-impact, routine diplomatic activity). Threshold is configurable via `application.yml`.
+
+2. **CAMEO code allowlist** — Only passes events matching specific CAMEO root codes: 14x (Protest), 17x-19x (Armed conflict/assault), 20x (Unconventional mass violence), plus natural disaster and infrastructure codes.
+
+3. **Geographic deduplication** — Clusters events within a configurable radius (default: 50km). Only the highest-severity event per cluster is retained. Uses PostGIS `ST_DWithin` for spatial proximity.
+
+4. **Recency filter** — Excludes events older than 48 hours (configurable). Prevents stale incidents from cluttering the globe.
+
+### 3.3 Database (PostgreSQL + PostGIS)
+
+PostgreSQL 16 runs in a Docker container with the PostGIS 3.4 extension enabled. Schema migrations are managed by Flyway and versioned in the repository under `src/main/resources/db/migration/`.
+
+#### 3.3.1 Core tables
+
+| Table | Key Columns | Index | Notes |
+|---|---|---|---|
+| **flights** | icao24 (PK), callsign, origin_country, latitude, longitude, altitude, velocity, heading, vertical_rate, on_ground, last_seen | GiST on location (geometry), B-tree on last_seen | Upserted by ICAO24 on each poll. Stale rows pruned. |
+| **incidents** | id (PK), gdelt_id, category, title, goldstein_score, location (geometry), event_date, actors, source_url, created_at | GiST on location, B-tree on category + event_date | Deduplicated by location + type + time window. |
+| **news_articles** | id (PK), incident_id (FK), title, source, url, published_at, tone, fetched_at | B-tree on incident_id + fetched_at | Cached with 1-hour TTL. Fetched on demand. |
+
+#### 3.3.2 PostGIS usage
+
+The `location` column in both `flights` and `incidents` uses the PostGIS `geometry(Point, 4326)` type, which stores WGS 84 coordinates (standard GPS). Key spatial queries:
+
+- `ST_DWithin(a.location, b.location, radius)` — Used in deduplication to cluster nearby incidents.
+- `ST_MakeEnvelope(lon1, lat1, lon2, lat2, 4326)` — Bounding box queries for viewport-based filtering (post-MVP).
+- `ST_Distance(a.location, b.location)` — Used for sorting incidents by proximity to a clicked point.
+
+## 4. Data Flow Patterns
+
+### 4.1 Flight data flow
+
+1. `FlightPollerService` fires every 15-30 seconds via `@Scheduled`.
+2. `OpenSkyClient` calls `GET https://opensky-network.org/api/states/all` with basic auth.
+3. Response (JSON array of aircraft state vectors) is deserialized into `FlightStateDTO` objects.
+4. `FlightService` maps DTOs to `Flight` entities, computing PostGIS `Point` geometry from lat/lng.
+5. `FlightRepository.upsertBatch()` performs an `INSERT ... ON CONFLICT (icao24) DO UPDATE`.
+6. Stale flights (`last_seen > 5 minutes ago`) are marked `on_ground = true` or deleted by a cleanup task.
+7. Frontend polls `GET /api/v1/flights` every 15-30 seconds. `FlightController` returns all active flights as `FlightResponseDTO`.
+8. Globe.gl renders each flight as a positioned plane icon with heading rotation.
+
+### 4.2 Incident data flow
+
+1. `IncidentPollerService` fires every 15-30 minutes via `@Scheduled`.
+2. `GdeltEventClient` calls the GDELT Event API v2 for events in the last 24 hours.
+3. Raw events (potentially thousands) are passed to `IncidentFilterPipeline`.
+4. Pipeline applies four filter stages: Goldstein threshold, CAMEO allowlist, geographic dedup, recency filter.
+5. Surviving events (typically 10-30) are mapped to `Incident` entities and persisted.
+6. Frontend polls `GET /api/v1/incidents` every 5-10 minutes. `IncidentController` returns active incidents as `IncidentResponseDTO`.
+7. Globe.gl renders each incident as a colored marker with category-specific styling.
+
+### 4.3 News article flow (on demand)
+
+1. User clicks an incident marker on the globe. Frontend sends `GET /api/v1/incidents/{id}/news`.
+2. `IncidentController` delegates to `NewsService`.
+3. `NewsService` checks the `news_articles` cache. If cached articles exist and `fetched_at < 1 hour ago`, return cached.
+4. Otherwise, `GdeltDocClient` queries the GDELT DOC API with keywords derived from the incident (event description, actor names, location).
+5. Returned articles are mapped to `NewsArticle` entities, persisted to cache, and returned as `NewsArticleResponseDTO`.
+6. Frontend renders the articles in the incident detail panel with headline, source, date, and link.
+
+## 5. REST API Contracts
+
+All endpoints are prefixed with `/api/v1`. Detailed request/response schemas are documented via springdoc-openapi and available at `/swagger-ui.html` when the backend is running.
+
+| Method | Endpoint | Response | Notes |
+|---|---|---|---|
+| **GET** | `/api/v1/flights` | `FlightResponseDTO[]` — array of active aircraft | Polled by frontend every 15-30s |
+| **GET** | `/api/v1/flights/{icao24}` | `FlightResponseDTO` — single aircraft detail | Triggered by click on flight marker |
+| **GET** | `/api/v1/incidents` | `IncidentResponseDTO[]` — filtered incidents | Supports `?category=` and `?minSeverity=` params |
+| **GET** | `/api/v1/incidents/{id}` | `IncidentResponseDTO` — single incident detail | Triggered by click on incident marker |
+| **GET** | `/api/v1/incidents/{id}/news` | `NewsArticleResponseDTO[]` — related articles | On-demand GDELT DOC fetch with cache |
+| **GET** | `/api/v1/health` | `{ status, uptime, dataSources }` | Includes external API connectivity check |
+
+## 6. Infrastructure and DevOps
+
+### 6.1 Local development environment
+
+The entire stack runs locally using Docker Compose for the database and standard tooling for the application:
+
+| Component | How to Run | Prerequisites |
+|---|---|---|
+| PostgreSQL + PostGIS | `docker-compose up -d db` | Docker Desktop installed |
+| Spring Boot backend | `./mvnw spring-boot:run` | JDK 17+, Maven 3.9+ |
+| React frontend | `cd frontend && npm run dev` | Node 18+, npm 9+ |
+| Full test suite | `./mvnw test && cd frontend && npm test` | All of the above |
+
+### 6.2 Docker Compose configuration
+
+A `docker-compose.yml` in the project root provides the PostgreSQL + PostGIS container. Key configuration:
+
+- **Image:** `postgis/postgis:16-3.4` (official PostGIS image based on PostgreSQL 16).
+- **Port mapping:** `5432:5432` for local access.
+- **Volume:** `./data/postgres:/var/lib/postgresql/data` for persistence across restarts.
+- **Environment:** `POSTGRES_DB=argus`, `POSTGRES_USER` and `POSTGRES_PASSWORD` from `.env` file (not committed).
+
+### 6.3 CI/CD pipeline (GitHub Actions)
+
+A GitHub Actions workflow runs on every push and pull request:
+
+1. Checkout code.
+2. Set up JDK 17 and Node 18.
+3. Start PostgreSQL + PostGIS service container.
+4. Run backend tests: `./mvnw test` (JUnit 5, Mockito, TestContainers).
+5. Run frontend tests: `npm test -- --coverage` (Jest, React Testing Library).
+6. Generate coverage reports: JaCoCo (backend), Jest coverage (frontend).
+7. Upload coverage artifacts.
+
+### 6.4 Environment variables and secrets
+
+Sensitive values are stored in a `.env` file (gitignored) and referenced in `application.yml`. A `.env.example` is committed with placeholder values:
+
+- `OPENSKY_USERNAME` / `OPENSKY_PASSWORD` — Free OpenSky Network account credentials.
+- `POSTGRES_USER` / `POSTGRES_PASSWORD` — Database credentials.
+- `SPRING_PROFILES_ACTIVE` — `dev` (local) or `prod` (deployed). Controls logging level and polling intervals.
+
+## 7. Cross-Cutting Concerns
+
+### 7.1 Error handling and resilience
+
+- **Circuit breaker pattern:** If an external API (OpenSky, GDELT) returns 5 consecutive errors, the poller backs off exponentially (30s, 60s, 120s, 240s) before retrying. The globe continues displaying cached data during outages.
+- **Graceful degradation:** If OpenSky is unreachable, flights display with last-known positions (marked as stale). If GDELT is unreachable, incidents continue showing cached events.
+- **Global exception handler:** A `@ControllerAdvice` class catches all exceptions and returns structured error responses (JSON with error code, message, timestamp).
+
+### 7.2 Logging and observability
+
+- SLF4J + Logback for structured logging. Log levels configurable per package via `application.yml`.
+- Spring Actuator enabled for health checks, metrics, and info endpoints.
+- Key metrics: API response time (p50, p95, p99), external API call count and error rate, polling cycle duration, active flight and incident counts.
+
+### 7.3 Security (MVP scope)
+
+- No authentication for MVP — the application runs locally and is not exposed to the internet.
+- CORS configured to allow localhost origins only.
+- OpenSky credentials stored in `.env` file, never committed to version control.
+- Post-MVP: Spring Security with JWT authentication will be added when user accounts are implemented.
+
+### 7.4 Performance considerations
+
+- **Flight data caching:** The backend caches the latest flight positions in-memory (with PostgreSQL as the source of truth). API responses are served from cache to keep p95 < 200ms.
+- **Globe rendering:** Globe.gl is configured with a maximum marker count. At low zoom levels, markers are clustered to prevent rendering thousands of individual plane icons.
+- **Database indexing:** GiST indexes on geometry columns ensure spatial queries (deduplication, bounding box) complete in < 10ms.
+- **Lazy news loading:** News articles are only fetched when a user clicks an incident, avoiding unnecessary API calls and database writes.
+
+## 8. Future Architecture Considerations
+
+The following architectural changes are anticipated for post-MVP releases. The current architecture is designed to accommodate these without major refactoring:
+
+- **WebSocket streaming (v2.0):** Replace polling with a Spring WebSocket/STOMP layer. The service layer and database remain unchanged; only the controller and frontend data-fetching layers need modification.
+- **AI summarization (v1.1):** Add an LLM API call (Claude or GPT) to the NewsService to generate incident briefings. The summary is cached alongside news articles.
+- **Event sourcing (v2.0):** Store all raw events from GDELT before filtering, enabling historical playback and re-processing with different filter parameters.
+- **Microservices extraction (v2.0+):** If scaling demands it, the flight poller, incident poller, and API server can be split into separate services communicating via a message queue (RabbitMQ or Kafka). The current package structure is already aligned with this boundary.
+
+## 9. Diagram Reference
+
+Two architecture diagrams accompany this document:
+
+**Diagram 1: High-Level System Architecture**
+
+Shows the three-tier topology: external data sources (OpenSky, GDELT Event API, GDELT DOC API) at the top, the Spring Boot backend container with internal components (pollers, service layer, REST controllers) in the middle, and PostgreSQL + React frontend at the bottom. Arrows indicate data flow direction and protocol (polling intervals, REST + JSON, read/write).
+
+**Diagram 2: Data Flow Architecture**
+
+Shows the two primary data pipelines side by side: the flight data pipeline (left: OpenSky → poller → service → PostGIS) and the incident data pipeline (right: GDELT → poller → filter pipeline → PostGIS). Below the divider, the on-demand user request flow shows how the React frontend queries both controllers and how the NewsService fetches articles from the GDELT DOC API.
+
+Both diagrams are also available as interactive SVG versions in the project README.

--- a/docs/Argus_PRD_v1_0.md
+++ b/docs/Argus_PRD_v1_0.md
@@ -1,0 +1,268 @@
+# ARGUS
+
+**Real-Time Global OSINT Monitoring Platform**
+
+**Product Requirements Document (PRD)**
+
+Version 1.0 | March 2026
+
+Classification: Internal
+
+| | |
+|---|---|
+| **Document Owner** | Tony Olivares — Project Lead |
+| **Status** | Draft |
+| **Last Updated** | March 24, 2026 |
+| **Reviewers** | N/A (Solo Project) |
+
+---
+
+## Table of Contents
+
+- [1. Executive Summary](#1-executive-summary)
+- [2. Problem Statement](#2-problem-statement)
+- [3. Target Audience](#3-target-audience)
+- [4. Product Vision](#4-product-vision)
+- [5. MVP Scope Definition](#5-mvp-scope-definition)
+- [6. User Stories](#6-user-stories)
+- [7. Technical Architecture](#7-technical-architecture)
+- [8. Data Sources](#8-data-sources)
+- [9. Testing Strategy](#9-testing-strategy)
+- [10. Success Metrics](#10-success-metrics)
+- [11. Risks and Mitigations](#11-risks-and-mitigations)
+- [12. Future Roadmap (Post-MVP)](#12-future-roadmap-post-mvp)
+- [13. Glossary](#13-glossary)
+- [14. Document Approval](#14-document-approval)
+
+---
+
+## 1. Executive Summary
+
+Argus is a real-time global monitoring platform that visualizes live air traffic, geopolitical incidents, and world events on an interactive 3D globe. Named after the hundred-eyed giant of Greek mythology, Argus provides journalists, OSINT (Open Source Intelligence) analysts, and globally-minded individuals with a unified situational awareness dashboard.
+
+The platform aggregates data from multiple open-source feeds — including live flight tracking, automated event detection, and global news monitoring — and presents it through an intuitive visual interface that makes complex world events immediately comprehensible.
+
+## 2. Problem Statement
+
+Currently, there is no free, unified platform that combines real-time flight tracking with geopolitical event monitoring in a single visual interface. Existing solutions suffer from several critical limitations:
+
+- **Flight trackers** (FlightRadar24, FlightAware) show air traffic but provide no geopolitical context.
+- **News aggregators** present text-based feeds with no spatial awareness or geographic visualization.
+- **OSINT tools** (Bellingcat, Liveuamap) focus on specific conflicts and require users to manually correlate data across multiple sources.
+- **Enterprise platforms** (Palantir Maven, Dataminr) provide comprehensive situational awareness but cost tens of thousands of dollars annually and are inaccessible to independent analysts.
+
+Argus bridges this gap by providing a free, open-source OSINT dashboard that combines live air traffic, auto-detected global incidents, and relevant news — all rendered on a single interactive globe.
+
+## 3. Target Audience
+
+### 3.1 Primary Users
+
+| Persona | Description | Key Needs |
+|---|---|---|
+| **OSINT Analysts** | Independent researchers tracking global events using publicly available data. | Real-time event detection, geographic context, source verification. |
+| **Journalists** | International correspondents and newsroom staff monitoring breaking events. | Fast incident alerts, relevant source articles, visual context for reporting. |
+| **Security Researchers** | Analysts at think tanks, NGOs, and academic institutions studying conflict and stability. | Historical event data, pattern recognition, exportable data. |
+
+### 3.2 Secondary Users
+
+- Aviation enthusiasts interested in real-time flight tracking with geopolitical overlay.
+- Educators teaching international relations, geopolitics, or data visualization.
+- General public seeking a visual way to understand global events beyond text-based news.
+
+## 4. Product Vision
+
+**Vision Statement:** *To democratize global situational awareness by providing a free, open-source platform that makes real-time world events visually accessible to everyone — from professional analysts to curious citizens.*
+
+### 4.1 Core Principles
+
+- **Open Data First** — Rely exclusively on free, publicly available data sources. No paywalls, no proprietary feeds.
+- **Visual Clarity** — Complex world events should be immediately comprehensible through intuitive visual design.
+- **Signal Over Noise** — Intelligent filtering surfaces meaningful events, not raw data dumps.
+- **Performance** — The globe must remain responsive even with thousands of data points rendered simultaneously.
+
+## 5. MVP Scope Definition
+
+### 5.1 In Scope (MVP)
+
+| Feature | Description | Priority | Complexity |
+|---|---|---|---|
+| **3D Globe** | Interactive Globe.gl visualization with dark theme, rotation, zoom, and click interactions. | P0 — Critical | Medium |
+| **Live Flights** | Aircraft positions from OpenSky Network, rendered as plane icons with heading. Polling interval: 10–30 seconds. Click reveals callsign, origin country, velocity, altitude. | P0 — Critical | Medium |
+| **Auto-Detected Incidents** | Global events from GDELT, filtered by severity (Goldstein Scale). Categories: Conflict, Disaster, Political, Infrastructure. Rendered as colored markers with category icons. | P0 — Critical | High |
+| **Incident Detail Panel** | Click an incident to see event summary, category, severity, timestamp, and related news articles sourced from GDELT DOC API. | P1 — Important | Medium |
+| **Flight Detail Panel** | Click a flight to see callsign, aircraft model (if available), origin country, altitude, velocity, heading, and vertical rate. | P1 — Important | Low |
+| **News Integration** | Related news articles fetched via GDELT DOC API when an incident is selected. Displays headline, source, timestamp, and link to original article. | P1 — Important | Medium |
+| **Event Filtering** | UI controls to filter incidents by category (conflict, disaster, political, infrastructure) and severity threshold. | P2 — Nice to Have | Low |
+
+### 5.2 Explicitly Out of Scope (MVP)
+
+- User authentication and accounts.
+- AI-powered event summaries (deferred to v1.1).
+- Historical playback / time-travel through past events.
+- Push notifications or alerting.
+- Mobile-responsive design (desktop-first for MVP).
+- Real-time WebSocket streaming (polling is sufficient for MVP).
+- Custom user annotations or saved views.
+- Deployment to cloud infrastructure (local demo + GitHub for MVP).
+
+## 6. User Stories
+
+### 6.1 Globe Interaction
+
+- As a **journalist**, I want to see a 3D globe with live data points so that I can get an immediate visual overview of global activity.
+- As an **OSINT analyst**, I want to click on a flight to see its details so that I can investigate unusual air traffic patterns.
+- As a **user**, I want to zoom and rotate the globe smoothly so that I can focus on specific regions of interest.
+
+### 6.2 Incident Monitoring
+
+- As a **journalist**, I want to see auto-detected global incidents on the globe so that I can spot breaking news events geographically.
+- As an **OSINT analyst**, I want to click an incident and see related news articles so that I can verify and research the event from primary sources.
+- As a **user**, I want to filter incidents by category so that I can focus on the types of events most relevant to my work.
+
+### 6.3 Acceptance Criteria Template
+
+Each user story in the sprint backlog must include acceptance criteria following this format:
+
+- GIVEN [precondition], WHEN [action], THEN [expected result].
+- Example: GIVEN the globe is loaded, WHEN I click on an aircraft icon, THEN a detail panel appears showing callsign, altitude, velocity, and origin country within 500ms.
+
+## 7. Technical Architecture
+
+### 7.1 System Overview
+
+Argus follows a standard three-tier architecture with clear separation of concerns:
+
+| Layer | Technology | Responsibility |
+|---|---|---|
+| **Frontend** | React 18 + Globe.gl | 3D globe rendering, user interactions, data visualization, state management. |
+| **Backend** | Spring Boot 3 (Java 17+) | REST API, external data aggregation, polling orchestration, business logic, caching. |
+| **Database** | PostgreSQL 16 + PostGIS | Persistent storage for cached flights, incidents, and news. Geospatial indexing and queries. |
+| **External APIs** | OpenSky, GDELT | Live flight data (OpenSky Network API), global event detection and news (GDELT Event + DOC APIs). |
+
+### 7.2 Tech Stack Justifications
+
+Each technology choice is documented in a corresponding Architecture Decision Record (ADR). Key decisions:
+
+- **Spring Boot over Node.js** — Enterprise credibility, strong typing, mature testing ecosystem (JUnit/Mockito). See [ADR-001](Argus_ADRs_v1_0.md#adr-001-spring-boot-for-backend-framework).
+- **Globe.gl over Cesium.js** — Dramatically simpler API, better visual-impact-to-complexity ratio, built on Three.js. See [ADR-002](Argus_ADRs_v1_0.md#adr-002-globegl-for-3d-globe-visualization).
+- **PostgreSQL + PostGIS over SQLite** — Concurrent read/write support, native geospatial queries, production-grade scalability. See [ADR-003](Argus_ADRs_v1_0.md#adr-003-postgresql-with-postgis-for-database).
+- **GDELT over manual curation** — Automated, global, free, unlimited, with built-in severity scoring and geocoding. See [ADR-004](Argus_ADRs_v1_0.md#adr-004-gdelt-for-automated-incident-detection).
+- **Full TDD approach** — JUnit 5 + Mockito for backend, Jest + React Testing Library for frontend. Tests written before implementation. See [ADR-005](Argus_ADRs_v1_0.md#adr-005-test-driven-development-tdd-methodology).
+
+### 7.3 API Design
+
+The backend exposes a RESTful API documented via OpenAPI 3.0 (Swagger). Core endpoints:
+
+| Method | Endpoint | Description |
+|---|---|---|
+| **GET** | `/api/v1/flights` | Returns all currently tracked aircraft positions. |
+| **GET** | `/api/v1/flights/{icao24}` | Returns detail for a specific aircraft by ICAO24 address. |
+| **GET** | `/api/v1/incidents` | Returns auto-detected incidents, filterable by category and severity. |
+| **GET** | `/api/v1/incidents/{id}` | Returns detail for a specific incident including metadata. |
+| **GET** | `/api/v1/incidents/{id}/news` | Returns related news articles for a specific incident. |
+| **GET** | `/api/v1/health` | Health check endpoint for monitoring. |
+
+### 7.4 Data Flow
+
+1. Scheduled pollers in Spring Boot fetch data from OpenSky (every 10–30s) and GDELT (every 15–30 min).
+2. Raw data is processed through filtering/transformation services and persisted to PostgreSQL.
+3. Frontend polls the Argus REST API at configurable intervals.
+4. Globe.gl renders the current state; user clicks trigger detail API calls.
+5. Incident detail requests trigger a secondary GDELT DOC API call for related news.
+
+## 8. Data Sources
+
+| Source | Data Provided | Cost | Rate Limit | Update Freq. |
+|---|---|---|---|---|
+| **OpenSky Network** | Live aircraft positions, velocity, callsign, ICAO24, origin country | Free | ~100 req/day (anon), 4000/day (registered) | 10–30 seconds |
+| **GDELT Event API** | Geocoded global events with type, severity (Goldstein Scale), actors, date | Free, unlimited | No hard limit | 15–30 minutes |
+| **GDELT DOC API** | News articles related to events/themes, with source, date, tone | Free, unlimited | No hard limit | On demand (per incident click) |
+
+## 9. Testing Strategy
+
+Argus follows a strict Test-Driven Development (TDD) methodology. Tests are written before implementation code for all features.
+
+### 9.1 Testing Pyramid
+
+| Layer | Tools | Scope | Target Coverage |
+|---|---|---|---|
+| **Unit Tests** | JUnit 5, Mockito | Service layer logic, data transformers, GDELT filters, DTO mapping | 90%+ on service classes |
+| **Integration Tests** | Spring Boot Test, TestContainers | REST endpoints, database queries, PostGIS operations | All API endpoints |
+| **Frontend Unit Tests** | Jest, React Testing Library | Component rendering, user interactions, state management | All interactive components |
+| **E2E Tests (Post-MVP)** | Playwright (future) | Full user flows, globe interaction, panel workflows | Deferred to v1.1 |
+
+### 9.2 TDD Workflow
+
+1. Write a failing test that defines the expected behavior.
+2. Write the minimum implementation code to make the test pass.
+3. Refactor the code while keeping tests green.
+4. Commit with a descriptive message referencing the relevant user story.
+
+## 10. Success Metrics
+
+MVP success is measured against the following criteria:
+
+| Metric | Target | Measurement |
+|---|---|---|
+| Globe Load Time | < 3 seconds on modern hardware | Chrome DevTools Performance |
+| Flight Data Freshness | < 30 seconds behind real-time | Timestamp comparison |
+| Incident Detection Latency | < 30 minutes from event to globe | GDELT timestamp vs. display |
+| API Response Time (p95) | < 200ms for all endpoints | Spring Actuator metrics |
+| Test Coverage (Backend) | > 80% line coverage | JaCoCo report |
+| Test Coverage (Frontend) | > 70% line coverage | Jest coverage report |
+| Zero Critical Bugs | No P0 bugs at MVP ship date | GitHub Issues tracker |
+
+## 11. Risks and Mitigations
+
+| Severity | Risk | Mitigation | Owner |
+|---|---|---|---|
+| **High** | OpenSky rate limits exceeded during development/demo | Implement response caching with configurable TTL. Create mock data fallback for demos. Register for free account (4000 req/day). | Backend Lead |
+| **High** | GDELT returns excessive noise (thousands of low-quality events) | Implement aggressive severity filters (Goldstein Scale threshold). Add category allowlist. Tune iteratively based on output quality. | Backend Lead |
+| **Medium** | Globe.gl performance degrades with thousands of flight markers | Implement viewport-based rendering (only show flights in current view). Use marker clustering at low zoom levels. Profile and optimize. | Frontend Lead |
+| **Medium** | Scope creep delays MVP delivery | Strict MVP scope defined in this PRD. All post-MVP features tracked in backlog with explicit deferral. Weekly scope review. | Project Lead |
+| **Low** | GDELT API becomes unavailable or changes schema | Abstract data source behind interface. Implement circuit breaker pattern. Cache last-known-good data for graceful degradation. | Backend Lead |
+
+## 12. Future Roadmap (Post-MVP)
+
+The following features are explicitly deferred from MVP and will be evaluated for future releases:
+
+### 12.1 v1.1 — Intelligence Layer
+
+- AI-powered incident summaries using an LLM API (Claude or GPT) to generate concise briefings for each incident.
+- Event clustering — automatically group related incidents (e.g., multiple protests in same country) into a single narrative.
+- Sentiment analysis overlay showing tone of media coverage by region.
+
+### 12.2 v1.2 — User Experience
+
+- User accounts with saved views and custom filter presets.
+- Push notifications for high-severity events via email or browser notifications.
+- Mobile-responsive design for tablet and phone use.
+- Historical playback — scrub through time to replay past events.
+
+### 12.3 v2.0 — Platform
+
+- Real-time WebSocket streaming replacing polling for sub-second updates.
+- Plugin system allowing community-contributed data sources.
+- API access tier for developers building on top of Argus data.
+- Cloud deployment with multi-region support.
+
+## 13. Glossary
+
+| Term | Definition |
+|---|---|
+| **OSINT** | Open Source Intelligence — intelligence derived from publicly available sources. |
+| **GDELT** | Global Database of Events, Language, and Tone — a free, open platform monitoring world events from news media. |
+| **Goldstein Scale** | A scale from -10 to +10 measuring the theoretical impact of an event type on country stability. |
+| **ICAO24** | A unique 24-bit address assigned to each aircraft transponder, used as identifier in flight tracking. |
+| **PostGIS** | A spatial database extension for PostgreSQL enabling geographic object storage and queries. |
+| **ADR** | Architecture Decision Record — a document capturing a significant technical decision and its rationale. |
+| **TDD** | Test-Driven Development — a methodology where tests are written before implementation code. |
+| **Globe.gl** | A Three.js-based library for rendering interactive 3D globes in the browser. |
+
+## 14. Document Approval
+
+This PRD is a living document and will be updated as requirements evolve. All changes must be tracked in the CHANGELOG and reviewed before merge.
+
+| Role | Name | Date | Status |
+|---|---|---|---|
+| Project Lead | Tony Olivares | March 24, 2026 | **APPROVED** |

--- a/docs/Argus_Sprint_Backlog_v1_0.md
+++ b/docs/Argus_Sprint_Backlog_v1_0.md
@@ -1,0 +1,1119 @@
+# ARGUS
+
+**Real-Time Global OSINT Monitoring Platform**
+
+**Sprint Backlog & GitHub Issues**
+
+Version 1.0 | March 2026
+
+7 Sprints | 36 Tickets | ~30 Days
+
+| | |
+|---|---|
+| **Document Owner** | Tony Olivares — Project Lead |
+| **Status** | Planning Complete |
+| **Last Updated** | March 24, 2026 |
+| **Methodology** | Full TDD, GitFlow |
+
+---
+
+## Table of Contents
+
+- [Sprint Plan Overview](#sprint-plan-overview)
+- [Sprint 1: Project Scaffolding and Infrastructure](#sprint-1-project-scaffolding-and-infrastructure)
+- [Sprint 2: Backend Core — Entities, Repositories, and External API Clients](#sprint-2-backend-core--entities-repositories-and-external-api-clients)
+- [Sprint 3: Backend Services — Business Logic and Polling](#sprint-3-backend-services--business-logic-and-polling)
+- [Sprint 4: REST API Controllers and Integration Tests](#sprint-4-rest-api-controllers-and-integration-tests)
+- [Sprint 5: Frontend — Globe Visualization and Flight Rendering](#sprint-5-frontend--globe-visualization-and-flight-rendering)
+- [Sprint 6: Frontend — Incident Markers, Detail Panel, and News](#sprint-6-frontend--incident-markers-detail-panel-and-news)
+- [Sprint 7: Polish, Integration Testing, and Documentation](#sprint-7-polish-integration-testing-and-documentation)
+- [Appendix: Critical Path](#appendix-critical-path)
+
+---
+
+## Sprint Plan Overview
+
+This document breaks the Argus MVP into 7 sprints containing 36 total tickets. Each ticket includes a unique ID, title, type, priority, labels, time estimate, dependencies, acceptance criteria, and technical notes. The tickets are ordered for sequential execution but can be parallelized where dependencies allow.
+
+All tickets follow the TDD methodology defined in [ADR-005](Argus_ADRs_v1_0.md#adr-005-test-driven-development-tdd-methodology): write failing tests first, implement to pass, then refactor. Acceptance criteria are written in GIVEN/WHEN/THEN format wherever applicable.
+
+### Sprint schedule
+
+| # | Sprint | Duration | Tickets | P0s | Status |
+|---|---|---|---|---|---|
+| **1** | Project Scaffolding and Infrastructure | 3–4 days | 6 | **4** | Planned |
+| **2** | Backend Core — Entities, Repositories, and External API Clients | 4–5 days | 6 | **4** | Planned |
+| **3** | Backend Services — Business Logic and Polling | 5–6 days | 6 | **5** | Planned |
+| **4** | REST API Controllers and Integration Tests | 3–4 days | 4 | **2** | Planned |
+| **5** | Frontend — Globe Visualization and Flight Rendering | 4–5 days | 4 | **3** | Planned |
+| **6** | Frontend — Incident Markers, Detail Panel, and News | 4–5 days | 5 | **2** | Planned |
+| **7** | Polish, Integration Testing, and Documentation | 3–4 days | 5 | **1** | Planned |
+
+### GitHub label definitions
+
+| Label | Color | Description |
+|---|---|---|
+| **backend** | `#0E8A16` | Changes to Spring Boot application code |
+| **frontend** | `#1D76DB` | Changes to React application code |
+| **infrastructure** | `#5319E7` | Docker, CI/CD, build configuration |
+| **database** | `#006B75` | Schema changes, migrations, PostGIS |
+| **api** | `#FBCA04` | REST endpoint changes |
+| **tdd** | `#D93F0B` | Ticket requires tests written first (TDD) |
+| **visualization** | `#C2E0C6` | Globe.gl rendering and visual features |
+| **ui** | `#BFD4F2` | User interface components and panels |
+| **integration** | `#BFDADC` | External API integration |
+| **service** | `#F9D0C4` | Backend service layer logic |
+| **scheduling** | `#FEF2C0` | Scheduled polling tasks |
+| **performance** | `#E4E669` | Performance optimization |
+| **documentation** | `#0075CA` | Documentation and README |
+| **testing** | `#D4C5F9` | Test infrastructure and E2E verification |
+| **devops** | `#EDEDED` | CI/CD and deployment |
+| **sprint-1** through **sprint-7** | `#FFFFFF` | Sprint assignment labels |
+
+---
+
+## Sprint 1: Project Scaffolding and Infrastructure
+
+**Goal:** *Establish the monorepo structure, CI/CD pipeline, database, and dev environment so that all subsequent work has a stable foundation.*
+
+**Duration:** 3–4 days | Tickets: 6 | P0 blockers: 4
+
+| ID | Title | Priority | Type | Estimate |
+|---|---|---|---|---|
+| **ARG-001** | Initialize Spring Boot project with Maven | **P0** | Task | 2–3 hours |
+| **ARG-002** | Initialize React frontend with Vite and Globe.gl | **P0** | Task | 2–3 hours |
+| **ARG-003** | Docker Compose for PostgreSQL + PostGIS | **P0** | Task | 1–2 hours |
+| **ARG-004** | Flyway migration setup with initial schema | **P0** | Task | 2–3 hours |
+| **ARG-005** | GitHub Actions CI pipeline | **P1** | Task | 2–3 hours |
+| **ARG-006** | Configure CORS and application profiles | **P1** | Task | 1 hour |
+
+### ARG-001: Initialize Spring Boot project with Maven
+
+| | |
+|---|---|
+| **Type** | Task |
+| **Priority** | **P0** |
+| **Labels** | backend, infrastructure, sprint-1 |
+| **Estimate** | 2–3 hours |
+| **PRD Ref** | Section 7.1 — System Overview |
+
+**Description**
+
+Create the Spring Boot 3.2 project using Spring Initializr. Configure Java 17, add core dependencies (Spring Web, Spring Data JPA, Flyway, springdoc-openapi, Actuator), and establish the base package structure defined in the Architecture Document. Use the Maven wrapper (mvnw) for portable builds.
+
+**Acceptance Criteria**
+
+- GIVEN a fresh clone, WHEN I run `./mvnw spring-boot:run`, THEN the app starts on port 8080 with no errors.
+- GIVEN the app is running, WHEN I hit `GET /api/v1/health`, THEN I receive a 200 response with `{ "status": "UP" }`.
+- GIVEN the app is running, WHEN I hit `/swagger-ui.html`, THEN the Swagger UI loads and displays the health endpoint.
+- The package structure matches the Architecture Document section 3.2.1 (controller, service, repository, model, dto, config, client packages all exist).
+- `application.yml` includes profiles for dev and prod with placeholder configuration.
+
+**Technical notes**
+
+- Use Maven with the Spring Boot parent POM. The Maven wrapper (mvnw) should be committed to the repo for portable builds.
+- Add `springdoc-openapi-starter-webmvc-ui` for Swagger auto-generation.
+- Create a HealthController manually (not just Actuator) to match the `/api/v1/health` endpoint contract.
+- Configure Spring Actuator to expose health, info, and metrics endpoints.
+
+### ARG-002: Initialize React frontend with Vite and Globe.gl
+
+| | |
+|---|---|
+| **Type** | Task |
+| **Priority** | **P0** |
+| **Labels** | frontend, infrastructure, sprint-1 |
+| **Estimate** | 2–3 hours |
+| **PRD Ref** | Section 7.1 — System Overview |
+
+**Description**
+
+Create the React 18 project using Vite with TypeScript template. Install core dependencies (react-globe.gl, axios or fetch wrapper) and dev dependencies (Jest, React Testing Library, ESLint, Prettier). Establish the frontend directory structure.
+
+**Acceptance Criteria**
+
+- GIVEN a fresh clone, WHEN I run `cd frontend && npm install && npm run dev`, THEN the dev server starts on port 5173.
+- GIVEN the dev server is running, WHEN I open localhost:5173, THEN I see a Globe.gl globe rendering with the default Earth texture on a dark background.
+- GIVEN the project, WHEN I run `npm test`, THEN Jest runs with zero failures (even if only a placeholder test exists).
+- The directory structure includes `src/components/`, `src/hooks/`, `src/services/`, `src/types/`, and `src/__tests__/`.
+- ESLint and Prettier configs are present and enforced.
+
+**Technical notes**
+
+- Use `react-globe.gl` (React wrapper) rather than raw `globe.gl` for cleaner JSX integration.
+- Set up a simple API client service (`src/services/api.ts`) with a configurable base URL pointing to localhost:8080.
+- Configure proxy in `vite.config.ts` to forward `/api` requests to the backend during development.
+
+### ARG-003: Docker Compose for PostgreSQL + PostGIS
+
+| | |
+|---|---|
+| **Type** | Task |
+| **Priority** | **P0** |
+| **Labels** | infrastructure, database, sprint-1 |
+| **Estimate** | 1–2 hours |
+| **PRD Ref** | Section 6.1 — Local Development Environment |
+
+**Description**
+
+Create a `docker-compose.yml` that runs PostgreSQL 16 with PostGIS 3.4. Include a `.env.example` with placeholder credentials and a `.gitignore` entry for `.env`. Verify PostGIS extension activates correctly.
+
+**Acceptance Criteria**
+
+- GIVEN Docker is running, WHEN I run `docker-compose up -d db`, THEN the PostgreSQL container starts and is accessible on port 5432.
+- GIVEN the DB is running, WHEN I connect and run `SELECT PostGIS_Version();`, THEN it returns the PostGIS version (3.4+).
+- A `.env.example` file exists with `POSTGRES_DB=argus`, `POSTGRES_USER`, and `POSTGRES_PASSWORD` placeholders.
+- The `.env` file is listed in `.gitignore`.
+- A `data/postgres/` directory is used for volume persistence and is gitignored.
+
+**Technical notes**
+
+- Use the official `postgis/postgis:16-3.4` Docker image.
+- Add a healthcheck in docker-compose.yml: `pg_isready -U $POSTGRES_USER`.
+
+### ARG-004: Flyway migration setup with initial schema
+
+| | |
+|---|---|
+| **Type** | Task |
+| **Priority** | **P0** |
+| **Labels** | backend, database, sprint-1 |
+| **Estimate** | 2–3 hours |
+| **Depends On** | ARG-001, ARG-003 |
+| **PRD Ref** | Architecture Doc Section 3.3 — Database |
+
+**Description**
+
+Configure Flyway in the Spring Boot application to manage database migrations. Create the initial migration (`V1__init.sql`) that enables PostGIS, creates the `flights`, `incidents`, and `news_articles` tables with proper column types, constraints, and spatial indexes.
+
+**Acceptance Criteria**
+
+- GIVEN the DB is running and I start the Spring Boot app, WHEN Flyway runs, THEN the schema is created with all three tables.
+- GIVEN the schema exists, WHEN I describe the `flights` table, THEN it has columns: icao24 (PK), callsign, origin_country, location (geometry(Point,4326)), altitude, velocity, heading, vertical_rate, on_ground, last_seen.
+- GIVEN the schema exists, WHEN I describe the `incidents` table, THEN it has columns: id (PK), gdelt_id, category, title, goldstein_score, location (geometry(Point,4326)), event_date, actors, source_url, created_at.
+- GIVEN the schema exists, WHEN I describe the `news_articles` table, THEN it has columns: id (PK), incident_id (FK), title, source, url, published_at, tone, fetched_at.
+- GiST indexes exist on `flights.location` and `incidents.location`.
+- B-tree indexes exist on `flights.last_seen`, `incidents.category`, `incidents.event_date`, and `news_articles.incident_id`.
+
+**Technical notes**
+
+- Migration file: `src/main/resources/db/migration/V1__init.sql`.
+- Enable PostGIS: `CREATE EXTENSION IF NOT EXISTS postgis;`
+- Use `geometry(Point, 4326)` for location columns (WGS 84 coordinate system).
+- Configure Flyway in `application.yml`: `spring.flyway.enabled=true`, `spring.flyway.locations=classpath:db/migration`.
+
+### ARG-005: GitHub Actions CI pipeline
+
+| | |
+|---|---|
+| **Type** | Task |
+| **Priority** | **P1** |
+| **Labels** | infrastructure, devops, sprint-1 |
+| **Estimate** | 2–3 hours |
+| **Depends On** | ARG-001, ARG-002, ARG-003 |
+| **PRD Ref** | Architecture Doc Section 6.3 — CI/CD Pipeline |
+
+**Description**
+
+Create a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs on every push and pull request. The workflow should build and test both backend and frontend, using a PostgreSQL service container for integration tests.
+
+**Acceptance Criteria**
+
+- GIVEN I push to any branch, WHEN GitHub Actions runs, THEN both backend and frontend tests execute.
+- The workflow provisions a PostgreSQL + PostGIS service container for the test run.
+- Backend step: `./mvnw test` completes successfully.
+- Frontend step: `cd frontend && npm test -- --coverage` completes successfully.
+- Coverage reports are uploaded as workflow artifacts.
+- The workflow fails if any test fails.
+
+**Technical notes**
+
+- Use the `postgis/postgis:16-3.4` service image in the workflow.
+- Set up JDK 17 with `actions/setup-java` and Node 18 with `actions/setup-node`.
+- Cache Maven and npm dependencies for faster builds.
+
+### ARG-006: Configure CORS and application profiles
+
+| | |
+|---|---|
+| **Type** | Task |
+| **Priority** | **P1** |
+| **Labels** | backend, infrastructure, sprint-1 |
+| **Estimate** | 1 hour |
+| **Depends On** | ARG-001 |
+| **PRD Ref** | Architecture Doc Section 7.3 — Security |
+
+**Description**
+
+Configure CORS in Spring Boot to allow requests from the frontend dev server (localhost:5173). Set up dev and prod Spring profiles with appropriate defaults for polling intervals, log levels, and database connection details.
+
+**Acceptance Criteria**
+
+- GIVEN the backend is running with the dev profile, WHEN the frontend makes a cross-origin request from localhost:5173, THEN the request succeeds without CORS errors.
+- `application-dev.yml` contains: debug-level logging, relaxed polling intervals (60s flights, 30min incidents), localhost DB connection.
+- `application-prod.yml` contains: info-level logging, standard polling intervals (15s flights, 15min incidents), configurable DB URL.
+- CORS configuration only allows localhost origins in dev profile.
+
+---
+
+## Sprint 2: Backend Core — Entities, Repositories, and External API Clients
+
+**Goal:** *Build the data model layer and create testable client wrappers for all external APIs, fully mocked and tested before any real API calls are made.*
+
+**Duration:** 4–5 days | Tickets: 6 | P0 blockers: 4
+
+| ID | Title | Priority | Type | Estimate |
+|---|---|---|---|---|
+| **ARG-007** | Flight JPA entity and repository with PostGIS | **P0** | Feature | 3–4 hours |
+| **ARG-008** | Incident JPA entity and repository with PostGIS | **P0** | Feature | 3–4 hours |
+| **ARG-009** | NewsArticle JPA entity and repository | **P1** | Feature | 2–3 hours |
+| **ARG-010** | OpenSky API client with mock tests | **P0** | Feature | 3–4 hours |
+| **ARG-011** | GDELT Event API client with mock tests | **P0** | Feature | 3–4 hours |
+| **ARG-012** | GDELT DOC API client with mock tests | **P1** | Feature | 2–3 hours |
+
+### ARG-007: Flight JPA entity and repository with PostGIS
+
+| | |
+|---|---|
+| **Type** | Feature |
+| **Priority** | **P0** |
+| **Labels** | backend, database, tdd, sprint-2 |
+| **Estimate** | 3–4 hours |
+| **Depends On** | ARG-004 |
+| **PRD Ref** | Architecture Doc Section 3.3.1 — Core Tables |
+
+**Description**
+
+Create the Flight JPA entity with Hibernate Spatial geometry mapping, the FlightRepository extending JpaRepository with custom spatial queries, and the FlightResponseDTO for API responses. All repository methods must have integration tests.
+
+**Acceptance Criteria**
+
+- Flight entity maps all columns defined in the schema (icao24 PK, callsign, origin_country, location as Point, altitude, velocity, heading, vertical_rate, on_ground, last_seen).
+- FlightRepository supports: findAll (active flights), findByIcao24, upsert batch operation (INSERT ON CONFLICT DO UPDATE).
+- FlightResponseDTO contains all fields needed by the frontend (icao24, callsign, originCountry, latitude, longitude, altitude, velocity, heading, verticalRate, onGround).
+- Integration tests verify: save and retrieve a flight, upsert updates existing flight, spatial column stores and retrieves correctly.
+- All tests pass with TestContainers PostgreSQL + PostGIS.
+
+**Technical notes**
+
+- Use Hibernate Spatial: `org.locationtech.jts.geom.Point` for the location column.
+- Add `@Column(columnDefinition = "geometry(Point,4326)")` annotation.
+- The upsert can use a `@Modifying @Query` with native SQL `INSERT ... ON CONFLICT`.
+- Use TestContainers with the `postgis/postgis:16-3.4` image for integration tests.
+
+### ARG-008: Incident JPA entity and repository with PostGIS
+
+| | |
+|---|---|
+| **Type** | Feature |
+| **Priority** | **P0** |
+| **Labels** | backend, database, tdd, sprint-2 |
+| **Estimate** | 3–4 hours |
+| **Depends On** | ARG-004 |
+| **PRD Ref** | Architecture Doc Section 3.3.1 — Core Tables |
+
+**Description**
+
+Create the Incident JPA entity, IncidentRepository with spatial and category-based queries, and IncidentResponseDTO. Include deduplication query support.
+
+**Acceptance Criteria**
+
+- Incident entity maps all columns: id (generated PK), gdelt_id, category (enum: CONFLICT, DISASTER, POLITICAL, INFRASTRUCTURE), title, goldstein_score, location as Point, event_date, actors, source_url, created_at.
+- IncidentRepository supports: findAll, findByCategory, findById, findNearby (ST_DWithin query for deduplication), deleteOlderThan.
+- IncidentResponseDTO contains all fields needed by the frontend plus a formatted category label.
+- Integration tests verify: save and retrieve, filter by category, spatial proximity query returns correct results.
+- All tests pass with TestContainers.
+
+**Technical notes**
+
+- Category should be a Java enum mapped with `@Enumerated(EnumType.STRING)`.
+- The ST_DWithin query: `SELECT * FROM incidents WHERE ST_DWithin(location, ST_SetSRID(ST_MakePoint(:lng, :lat), 4326), :radius)`.
+- Use `@Query` with `nativeQuery=true` for PostGIS-specific queries.
+
+### ARG-009: NewsArticle JPA entity and repository
+
+| | |
+|---|---|
+| **Type** | Feature |
+| **Priority** | **P1** |
+| **Labels** | backend, database, tdd, sprint-2 |
+| **Estimate** | 2–3 hours |
+| **Depends On** | ARG-004, ARG-008 |
+| **PRD Ref** | Architecture Doc Section 3.3.1 — Core Tables |
+
+**Description**
+
+Create the NewsArticle JPA entity with a foreign key to incidents, the NewsArticleRepository, and the NewsArticleResponseDTO.
+
+**Acceptance Criteria**
+
+- NewsArticle entity maps: id (PK), incident_id (FK to incidents), title, source, url, published_at, tone (float), fetched_at.
+- NewsArticleRepository supports: findByIncidentId, findByIncidentIdAndFetchedAtAfter (cache check), deleteByFetchedAtBefore (cache cleanup).
+- NewsArticleResponseDTO: title, source, url, publishedAt, tone.
+- Integration tests verify: save with incident FK, retrieve by incident ID, cache freshness check query.
+- All tests pass with TestContainers.
+
+### ARG-010: OpenSky API client with mock tests
+
+| | |
+|---|---|
+| **Type** | Feature |
+| **Priority** | **P0** |
+| **Labels** | backend, integration, tdd, sprint-2 |
+| **Estimate** | 3–4 hours |
+| **Depends On** | ARG-001 |
+| **PRD Ref** | ADR-006 — OpenSky Network |
+
+**Description**
+
+Create the OpenSkyClient class that calls the OpenSky `/states/all` endpoint and deserializes the response into DTOs. The client must be fully unit-testable with mocked HTTP responses.
+
+**Acceptance Criteria**
+
+- OpenSkyClient has a method `fetchAllStates()` that returns `List<OpenSkyStateDTO>`.
+- OpenSkyStateDTO maps: icao24, callsign, origin_country, longitude, latitude, baro_altitude, velocity, true_track, vertical_rate, on_ground.
+- Unit tests mock the RestTemplate/WebClient response and verify: successful deserialization of a sample JSON payload, handling of empty response (no aircraft), handling of HTTP error (returns empty list, logs warning), handling of rate limit (429 response, logs warning).
+- OpenSky credentials are read from `application.yml` (`opensky.username`, `opensky.password`).
+- All tests pass without making real API calls.
+
+**Technical notes**
+
+- OpenSky returns a JSON object with a "states" array where each state is a positional array (not named keys). Custom deserialization may be needed.
+- Use RestTemplate with basic auth for the HTTP call. Inject the RestTemplate so it can be mocked.
+- Sample response format: `{ "time": 123, "states": [["icao24", "callsign", "origin", ...], ...] }`.
+
+### ARG-011: GDELT Event API client with mock tests
+
+| | |
+|---|---|
+| **Type** | Feature |
+| **Priority** | **P0** |
+| **Labels** | backend, integration, tdd, sprint-2 |
+| **Estimate** | 3–4 hours |
+| **Depends On** | ARG-001 |
+| **PRD Ref** | ADR-004 — GDELT for Incident Detection |
+
+**Description**
+
+Create the GdeltEventClient that queries the GDELT Event API v2 for recent events and deserializes into DTOs. Fully mocked and tested.
+
+**Acceptance Criteria**
+
+- GdeltEventClient has a method `fetchRecentEvents(int hoursBack)` returning `List<GdeltEventDTO>`.
+- GdeltEventDTO maps: gdeltId, eventDate, actor1Name, actor2Name, eventCode (CAMEO), goldsteinScale, numMentions, avgTone, latitude, longitude, sourceUrl.
+- Unit tests verify: successful deserialization of sample GDELT response, empty result handling, malformed response handling (partial data, missing fields), HTTP error handling.
+- All tests pass without making real API calls.
+
+**Technical notes**
+
+- GDELT Event API v2 endpoint: `https://api.gdeltproject.org/api/v2/events/events`
+- The response format can be CSV or JSON depending on query parameters. Use JSON format (`&format=json`).
+- GDELT has no authentication — no API key needed.
+
+### ARG-012: GDELT DOC API client with mock tests
+
+| | |
+|---|---|
+| **Type** | Feature |
+| **Priority** | **P1** |
+| **Labels** | backend, integration, tdd, sprint-2 |
+| **Estimate** | 2–3 hours |
+| **Depends On** | ARG-001 |
+| **PRD Ref** | ADR-008 — GDELT DOC API for News |
+
+**Description**
+
+Create the GdeltDocClient that queries the GDELT DOC API for news articles by keyword/theme. Fully mocked and tested.
+
+**Acceptance Criteria**
+
+- GdeltDocClient has a method `fetchArticles(String query, int maxResults)` returning `List<GdeltArticleDTO>`.
+- GdeltArticleDTO maps: title, url, source, publishDate, tone, language.
+- Unit tests verify: successful deserialization, empty results, HTTP error handling.
+- Query construction supports keyword search with optional location and date range parameters.
+- All tests pass without making real API calls.
+
+**Technical notes**
+
+- GDELT DOC API endpoint: `https://api.gdeltproject.org/api/v2/doc/doc?query=KEYWORD&mode=artlist&format=json`
+- Max results are controlled by `&maxrecords=N` (default 25, max 250).
+
+---
+
+## Sprint 3: Backend Services — Business Logic and Polling
+
+**Goal:** *Implement the core service layer: flight processing, incident filtering pipeline, news retrieval with caching, and the scheduled pollers that drive the data flow.*
+
+**Duration:** 5–6 days | Tickets: 6 | P0 blockers: 5
+
+| ID | Title | Priority | Type | Estimate |
+|---|---|---|---|---|
+| **ARG-013** | FlightService — processing and transformation logic | **P0** | Feature | 3–4 hours |
+| **ARG-014** | IncidentFilterPipeline — multi-stage event filtering | **P0** | Feature | 5–6 hours |
+| **ARG-015** | IncidentService — incident processing and retrieval | **P0** | Feature | 3–4 hours |
+| **ARG-016** | NewsService — article retrieval with caching | **P1** | Feature | 3–4 hours |
+| **ARG-017** | FlightPollerService — scheduled flight data ingestion | **P0** | Feature | 2–3 hours |
+| **ARG-018** | IncidentPollerService — scheduled incident detection | **P0** | Feature | 2–3 hours |
+
+### ARG-013: FlightService — processing and transformation logic
+
+| | |
+|---|---|
+| **Type** | Feature |
+| **Priority** | **P0** |
+| **Labels** | backend, service, tdd, sprint-3 |
+| **Estimate** | 3–4 hours |
+| **Depends On** | ARG-007, ARG-010 |
+| **PRD Ref** | Architecture Doc Section 4.1 — Flight Data Flow |
+
+**Description**
+
+Create FlightService that transforms OpenSky DTOs into Flight entities, handles upsert logic, and manages stale flight cleanup. This is the bridge between the API client and the database.
+
+**Acceptance Criteria**
+
+- `FlightService.processFlightStates(List<OpenSkyStateDTO>)` transforms DTOs into Flight entities with PostGIS Point geometry and upserts them.
+- `FlightService.getActiveFlights()` returns all flights with `last_seen` within the configured threshold (default 5 minutes).
+- `FlightService.getFlightByIcao24(String)` returns a single flight or throws NotFoundException.
+- `FlightService.cleanupStaleFlights()` removes or marks inactive any flights not seen within the threshold.
+- Unit tests (Mockito) verify: DTO-to-entity mapping correctness, null/empty callsign handling, on_ground flag logic, stale cleanup logic.
+- All tests use mocked FlightRepository.
+
+### ARG-014: IncidentFilterPipeline — multi-stage event filtering
+
+| | |
+|---|---|
+| **Type** | Feature |
+| **Priority** | **P0** |
+| **Labels** | backend, service, tdd, sprint-3 |
+| **Estimate** | 5–6 hours |
+| **Depends On** | ARG-008, ARG-011 |
+| **PRD Ref** | Architecture Doc Section 3.2.3 — Incident Filter Pipeline |
+
+**Description**
+
+Implement the four-stage incident filter pipeline that transforms thousands of raw GDELT events into 10–30 meaningful incidents. This is the most critical piece of business logic and the primary technical talking point for interviews.
+
+**Acceptance Criteria**
+
+- **Stage 1 (Goldstein filter):** Events with goldsteinScale between -3.0 and +3.0 are excluded. Threshold is configurable via `application.yml` (`argus.filter.goldstein-threshold`).
+- **Stage 2 (CAMEO filter):** Only events with root CAMEO codes in the allowlist pass. Default allowlist: 14x (Protest), 17x–19x (Coerce/Assault/Fight), 20x (Mass violence). Allowlist is configurable.
+- **Stage 3 (Geographic dedup):** Events within 50km of each other with the same CAMEO root code are clustered. Only the highest-severity event per cluster is retained. Uses PostGIS `ST_DWithin`.
+- **Stage 4 (Recency filter):** Events older than 48 hours are excluded. Threshold is configurable.
+- The pipeline is implemented as a chain of filter stages, each independently testable.
+- Unit tests verify each stage independently AND the full pipeline end-to-end with sample GDELT data.
+- Given 500 sample events, the pipeline reduces to fewer than 50 (exact number depends on sample data distribution).
+
+**Technical notes**
+
+- Implement each stage as a separate class implementing a common interface (e.g., `EventFilter` with method `List<GdeltEventDTO> filter(List<GdeltEventDTO> events)`).
+- The pipeline chains them: goldstein → cameo → dedup → recency.
+- Geographic dedup is the trickiest stage — it requires a spatial query against existing incidents in the database.
+- CAMEO codes: first two digits are the root code. 14 = Protest, 17 = Coerce, 18 = Assault, 19 = Fight, 20 = Engage in mass violence.
+
+### ARG-015: IncidentService — incident processing and retrieval
+
+| | |
+|---|---|
+| **Type** | Feature |
+| **Priority** | **P0** |
+| **Labels** | backend, service, tdd, sprint-3 |
+| **Estimate** | 3–4 hours |
+| **Depends On** | ARG-008, ARG-014 |
+| **PRD Ref** | Architecture Doc Section 4.2 — Incident Data Flow |
+
+**Description**
+
+Create IncidentService that processes filtered events into Incident entities, persists them, and provides retrieval methods with optional category and severity filtering.
+
+**Acceptance Criteria**
+
+- `IncidentService.processFilteredEvents(List<GdeltEventDTO>)` maps DTOs to Incident entities, assigns categories, and persists.
+- `IncidentService.getActiveIncidents(Optional<Category>, Optional<Double>)` returns filtered incidents.
+- `IncidentService.getIncidentById(Long)` returns a single incident or throws NotFoundException.
+- Category mapping: CAMEO codes are mapped to IncidentCategory enum (CONFLICT, DISASTER, POLITICAL, INFRASTRUCTURE).
+- Unit tests verify: DTO-to-entity mapping, category assignment logic, filtering by category and severity.
+
+### ARG-016: NewsService — article retrieval with caching
+
+| | |
+|---|---|
+| **Type** | Feature |
+| **Priority** | **P1** |
+| **Labels** | backend, service, tdd, sprint-3 |
+| **Estimate** | 3–4 hours |
+| **Depends On** | ARG-009, ARG-012, ARG-015 |
+| **PRD Ref** | Architecture Doc Section 4.3 — News Article Flow |
+
+**Description**
+
+Create NewsService that retrieves news articles for a given incident, implements a 1-hour cache in PostgreSQL, and constructs search queries from incident metadata.
+
+**Acceptance Criteria**
+
+- `NewsService.getNewsForIncident(Long incidentId)` returns `List<NewsArticleResponseDTO>`.
+- If cached articles exist with `fetched_at < 1 hour ago`, return cached results without calling GDELT.
+- If cache is stale or empty, call GdeltDocClient with a query built from: incident title, actor names, location name.
+- New articles are persisted to `news_articles` with `fetched_at = now()`.
+- Unit tests verify: cache hit (no API call), cache miss (API called, results cached), empty API response handling, query construction from incident metadata.
+
+### ARG-017: FlightPollerService — scheduled flight data ingestion
+
+| | |
+|---|---|
+| **Type** | Feature |
+| **Priority** | **P0** |
+| **Labels** | backend, service, scheduling, tdd, sprint-3 |
+| **Estimate** | 2–3 hours |
+| **Depends On** | ARG-010, ARG-013 |
+| **PRD Ref** | Architecture Doc Section 3.2.2 — Scheduled Polling |
+
+**Description**
+
+Create the scheduled service that polls OpenSky at configurable intervals and delegates to FlightService for processing. Include error handling with exponential backoff.
+
+**Acceptance Criteria**
+
+- FlightPollerService runs automatically via `@Scheduled` at an interval configured by `argus.polling.flights-interval-ms` (default: 15000).
+- Each poll cycle: calls `OpenSkyClient.fetchAllStates()`, passes results to `FlightService.processFlightStates()`, then calls `FlightService.cleanupStaleFlights()`.
+- If OpenSkyClient throws an exception, the poller logs the error and continues (does not crash the scheduler).
+- After 5 consecutive failures, polling interval doubles (exponential backoff). Resets on success.
+- Unit tests verify: successful poll cycle, error handling, backoff behavior.
+
+### ARG-018: IncidentPollerService — scheduled incident detection
+
+| | |
+|---|---|
+| **Type** | Feature |
+| **Priority** | **P0** |
+| **Labels** | backend, service, scheduling, tdd, sprint-3 |
+| **Estimate** | 2–3 hours |
+| **Depends On** | ARG-011, ARG-014, ARG-015 |
+| **PRD Ref** | Architecture Doc Section 3.2.2 — Scheduled Polling |
+
+**Description**
+
+Create the scheduled service that polls GDELT at configurable intervals, runs the filter pipeline, and delegates to IncidentService for persistence.
+
+**Acceptance Criteria**
+
+- IncidentPollerService runs via `@Scheduled` at `argus.polling.incidents-interval-ms` (default: 900000 = 15 minutes).
+- Each poll cycle: calls `GdeltEventClient.fetchRecentEvents(24)`, passes results through IncidentFilterPipeline, then passes survivors to `IncidentService.processFilteredEvents()`.
+- Error handling and backoff mirror FlightPollerService.
+- Unit tests verify: successful poll cycle end-to-end, error handling, logging of filter statistics (e.g., "Processed 1200 raw events → 23 incidents").
+
+---
+
+## Sprint 4: REST API Controllers and Integration Tests
+
+**Goal:** *Expose the backend data through documented REST endpoints and verify the full request lifecycle with integration tests.*
+
+**Duration:** 3–4 days | Tickets: 4 | P0 blockers: 2
+
+| ID | Title | Priority | Type | Estimate |
+|---|---|---|---|---|
+| **ARG-019** | FlightController — flight data REST endpoints | **P0** | Feature | 2–3 hours |
+| **ARG-020** | IncidentController — incident REST endpoints with filtering | **P0** | Feature | 3–4 hours |
+| **ARG-021** | Global exception handler and error response format | **P1** | Feature | 1–2 hours |
+| **ARG-022** | Swagger/OpenAPI documentation verification | **P1** | Task | 1 hour |
+
+### ARG-019: FlightController — flight data REST endpoints
+
+| | |
+|---|---|
+| **Type** | Feature |
+| **Priority** | **P0** |
+| **Labels** | backend, api, tdd, sprint-4 |
+| **Estimate** | 2–3 hours |
+| **Depends On** | ARG-013 |
+| **PRD Ref** | Architecture Doc Section 5 — REST API Contracts |
+
+**Description**
+
+Create the FlightController exposing `GET /api/v1/flights` and `GET /api/v1/flights/{icao24}`. Include proper OpenAPI annotations for Swagger documentation.
+
+**Acceptance Criteria**
+
+- `GET /api/v1/flights` returns 200 with a JSON array of FlightResponseDTO objects.
+- `GET /api/v1/flights/{icao24}` returns 200 with a single FlightResponseDTO, or 404 if not found.
+- Both endpoints include OpenAPI annotations (`@Operation`, `@ApiResponse`) for Swagger docs.
+- Integration tests verify: list all flights, get by ICAO24, 404 for unknown ICAO24.
+- Response time is under 200ms for 1000 cached flights (verified in integration test with seeded data).
+
+### ARG-020: IncidentController — incident REST endpoints with filtering
+
+| | |
+|---|---|
+| **Type** | Feature |
+| **Priority** | **P0** |
+| **Labels** | backend, api, tdd, sprint-4 |
+| **Estimate** | 3–4 hours |
+| **Depends On** | ARG-015, ARG-016 |
+| **PRD Ref** | Architecture Doc Section 5 — REST API Contracts |
+
+**Description**
+
+Create the IncidentController exposing incident endpoints with category and severity filtering, plus the news sub-resource endpoint.
+
+**Acceptance Criteria**
+
+- `GET /api/v1/incidents` returns 200 with a JSON array of IncidentResponseDTO objects.
+- `GET /api/v1/incidents?category=CONFLICT` returns only conflict incidents.
+- `GET /api/v1/incidents?minSeverity=-7.0` returns only incidents with goldstein_score <= -7.0.
+- `GET /api/v1/incidents/{id}` returns 200 with a single incident, or 404.
+- `GET /api/v1/incidents/{id}/news` returns 200 with a JSON array of NewsArticleResponseDTO objects.
+- All endpoints include OpenAPI annotations.
+- Integration tests verify all endpoint behaviors including filter combinations.
+
+### ARG-021: Global exception handler and error response format
+
+| | |
+|---|---|
+| **Type** | Feature |
+| **Priority** | **P1** |
+| **Labels** | backend, api, sprint-4 |
+| **Estimate** | 1–2 hours |
+| **Depends On** | ARG-019, ARG-020 |
+| **PRD Ref** | Architecture Doc Section 7.1 — Error Handling |
+
+**Description**
+
+Create a `@ControllerAdvice` class that catches all exceptions and returns structured JSON error responses.
+
+**Acceptance Criteria**
+
+- All API errors return a consistent JSON format: `{ "error": "NOT_FOUND", "message": "Flight with ICAO24 'ABC123' not found", "timestamp": "...", "path": "/api/v1/flights/ABC123" }`.
+- 404 Not Found: NotFoundException is caught and returns 404.
+- 400 Bad Request: Invalid filter parameters return 400 with a descriptive message.
+- 500 Internal Server Error: Unhandled exceptions return 500 with a generic message (no stack trace leak).
+- Unit tests verify each error scenario.
+
+### ARG-022: Swagger/OpenAPI documentation verification
+
+| | |
+|---|---|
+| **Type** | Task |
+| **Priority** | **P1** |
+| **Labels** | backend, documentation, sprint-4 |
+| **Estimate** | 1 hour |
+| **Depends On** | ARG-019, ARG-020, ARG-021 |
+| **PRD Ref** | PRD Section 7.3 — API Design |
+
+**Description**
+
+Verify that the auto-generated Swagger UI at `/swagger-ui.html` correctly documents all endpoints with request parameters, response schemas, and example values. Add `@Schema` annotations to DTOs where needed.
+
+**Acceptance Criteria**
+
+- Swagger UI loads at `/swagger-ui.html` and displays all 6 endpoints.
+- Each endpoint shows: HTTP method, path, parameters (with types), response schema, and example response.
+- DTOs have `@Schema` annotations with descriptions on all fields.
+- The OpenAPI JSON spec is downloadable at `/v3/api-docs`.
+
+---
+
+## Sprint 5: Frontend — Globe Visualization and Flight Rendering
+
+**Goal:** *Build the core visual experience: the 3D globe with live flight markers that update in real-time via polling.*
+
+**Duration:** 4–5 days | Tickets: 4 | P0 blockers: 3
+
+| ID | Title | Priority | Type | Estimate |
+|---|---|---|---|---|
+| **ARG-023** | Globe component with dark theme and controls | **P0** | Feature | 3–4 hours |
+| **ARG-024** | Flight data polling hook and API service | **P0** | Feature | 2–3 hours |
+| **ARG-025** | Flight markers on the globe with heading rotation | **P0** | Feature | 4–5 hours |
+| **ARG-026** | Flight detail panel on click | **P1** | Feature | 3–4 hours |
+
+### ARG-023: Globe component with dark theme and controls
+
+| | |
+|---|---|
+| **Type** | Feature |
+| **Priority** | **P0** |
+| **Labels** | frontend, visualization, sprint-5 |
+| **Estimate** | 3–4 hours |
+| **Depends On** | ARG-002 |
+| **PRD Ref** | PRD Section 5.1 — 3D Globe |
+
+**Description**
+
+Build the main Globe React component using react-globe.gl with a dark professional theme, smooth rotation/zoom/pan controls, and atmosphere glow effect.
+
+**Acceptance Criteria**
+
+- GIVEN the app loads, WHEN the globe renders, THEN it displays a dark-themed Earth with visible country borders and atmosphere glow.
+- GIVEN the globe is rendered, WHEN I click and drag, THEN the globe rotates smoothly.
+- GIVEN the globe is rendered, WHEN I scroll, THEN the globe zooms in/out smoothly.
+- The globe fills the viewport (full-screen, no scrollbars).
+- Globe.gl auto-rotates slowly when not interacted with. Rotation stops on user interaction and resumes after 3 seconds of inactivity.
+- Component test: Globe component renders without errors.
+
+**Technical notes**
+
+- Use `globeImageUrl` with a dark earth texture (night lights or dark political map).
+- Set `atmosphereColor` and `atmosphereAltitude` for the glow effect.
+- Use `React.useRef` for the globe instance to allow programmatic control.
+
+### ARG-024: Flight data polling hook and API service
+
+| | |
+|---|---|
+| **Type** | Feature |
+| **Priority** | **P0** |
+| **Labels** | frontend, data, tdd, sprint-5 |
+| **Estimate** | 2–3 hours |
+| **Depends On** | ARG-002, ARG-019 |
+| **PRD Ref** | Architecture Doc Section 4.1 — Flight Data Flow |
+
+**Description**
+
+Create the `useFlights` custom hook and the API service function to poll `GET /api/v1/flights` at configurable intervals.
+
+**Acceptance Criteria**
+
+- `useFlights()` hook returns `{ flights, isLoading, error, lastUpdated }`.
+- The hook polls `GET /api/v1/flights` every 15 seconds (configurable).
+- While loading the first fetch, `isLoading` is true. After first load, subsequent polls update silently.
+- If the API returns an error, the error state is set but previously fetched flights remain displayed.
+- Jest tests verify: initial loading state, successful data fetch, error handling, polling interval.
+
+**Technical notes**
+
+- Consider using React Query (TanStack Query) for built-in polling, caching, and stale-while-revalidate behavior.
+- If not using React Query, use `setInterval` with cleanup in `useEffect`.
+
+### ARG-025: Flight markers on the globe with heading rotation
+
+| | |
+|---|---|
+| **Type** | Feature |
+| **Priority** | **P0** |
+| **Labels** | frontend, visualization, sprint-5 |
+| **Estimate** | 4–5 hours |
+| **Depends On** | ARG-023, ARG-024 |
+| **PRD Ref** | PRD Section 5.1 — Live Flights |
+
+**Description**
+
+Render flight positions from `useFlights` as plane icons on the globe, rotated to match their heading. Markers should update smoothly when new data arrives.
+
+**Acceptance Criteria**
+
+- GIVEN flights data is loaded, WHEN the globe renders, THEN each active flight appears as a small plane icon at its lat/lng position.
+- Plane icons are rotated to match the flight's heading (true_track).
+- GIVEN new poll data arrives, WHEN positions change, THEN markers update smoothly (no flicker or jump).
+- GIVEN 1000+ flights are visible, WHEN I zoom out to see the full globe, THEN rendering stays smooth (>30fps).
+- GIVEN the globe is zoomed in, WHEN I hover over a plane, THEN a tooltip shows the callsign.
+- Component test: flight markers render for given mock flight data.
+
+**Technical notes**
+
+- Use Globe.gl's `htmlElementsData` layer for custom plane icons (allows CSS rotation for heading).
+- Alternative: use `pointsData` with custom SVG markers if HTML overlay is too heavy at scale.
+- For performance at 1000+ markers, consider switching to `pointsData` at low zoom levels.
+
+### ARG-026: Flight detail panel on click
+
+| | |
+|---|---|
+| **Type** | Feature |
+| **Priority** | **P1** |
+| **Labels** | frontend, ui, tdd, sprint-5 |
+| **Estimate** | 3–4 hours |
+| **Depends On** | ARG-025 |
+| **PRD Ref** | PRD Section 5.1 — Flight Detail Panel |
+
+**Description**
+
+When a user clicks a flight marker, display a side panel or popup with detailed flight information.
+
+**Acceptance Criteria**
+
+- GIVEN the globe is showing flights, WHEN I click a plane marker, THEN a detail panel slides in from the right side.
+- The panel displays: callsign (large, bold), ICAO24 address, origin country (with flag emoji or icon), altitude (formatted with units), velocity (formatted), heading (with compass direction), vertical rate (with up/down indicator), and on-ground status.
+- GIVEN a panel is open, WHEN I click a different flight, THEN the panel updates to show the new flight.
+- GIVEN a panel is open, WHEN I click the close button or click empty space on the globe, THEN the panel closes.
+- Component tests: panel renders with mock flight data, panel closes on close button click.
+
+---
+
+## Sprint 6: Frontend — Incident Markers, Detail Panel, and News
+
+**Goal:** *Complete the second major data layer: incidents on the globe with click-through detail panels and related news articles.*
+
+**Duration:** 4–5 days | Tickets: 5 | P0 blockers: 2
+
+| ID | Title | Priority | Type | Estimate |
+|---|---|---|---|---|
+| **ARG-027** | Incident data polling hook and API service | **P0** | Feature | 2–3 hours |
+| **ARG-028** | Incident markers on the globe with category styling | **P0** | Feature | 4–5 hours |
+| **ARG-029** | Incident detail panel with metadata | **P1** | Feature | 3–4 hours |
+| **ARG-030** | News articles list in incident detail panel | **P1** | Feature | 3–4 hours |
+| **ARG-031** | Event filter bar UI | **P2** | Feature | 2–3 hours |
+
+### ARG-027: Incident data polling hook and API service
+
+| | |
+|---|---|
+| **Type** | Feature |
+| **Priority** | **P0** |
+| **Labels** | frontend, data, tdd, sprint-6 |
+| **Estimate** | 2–3 hours |
+| **Depends On** | ARG-020 |
+| **PRD Ref** | Architecture Doc Section 4.2 — Incident Data Flow |
+
+**Description**
+
+Create the `useIncidents` custom hook to poll `GET /api/v1/incidents` at configurable intervals with optional category and severity filters.
+
+**Acceptance Criteria**
+
+- `useIncidents(filters?)` hook returns `{ incidents, isLoading, error, lastUpdated }`.
+- The hook polls every 5 minutes (configurable). Supports category and minSeverity filter parameters.
+- When filters change, the hook immediately refetches.
+- Error handling mirrors useFlights (stale data preserved on error).
+- Jest tests verify: initial fetch, filter application, error handling.
+
+### ARG-028: Incident markers on the globe with category styling
+
+| | |
+|---|---|
+| **Type** | Feature |
+| **Priority** | **P0** |
+| **Labels** | frontend, visualization, sprint-6 |
+| **Estimate** | 4–5 hours |
+| **Depends On** | ARG-023, ARG-027 |
+| **PRD Ref** | PRD Section 5.1 — Auto-Detected Incidents |
+
+**Description**
+
+Render incidents as colored markers on the globe with visual styling that communicates category and severity.
+
+**Acceptance Criteria**
+
+- Each incident category has a distinct color: CONFLICT = red, DISASTER = orange, POLITICAL = yellow, INFRASTRUCTURE = purple.
+- Marker size scales with severity (higher goldstein magnitude = larger marker).
+- Incidents render as pulsing circles or ring markers (not plane icons) to visually distinguish from flights.
+- GIVEN 30 incidents are active, WHEN the globe renders, THEN all incidents are visible and clickable.
+- GIVEN incidents of mixed categories, WHEN I look at the globe, THEN I can visually distinguish categories by color.
+- Component test: incident markers render with correct colors for given mock data.
+
+**Technical notes**
+
+- Use Globe.gl's `ringsData` layer for pulsing ring markers, or `htmlElementsData` for custom styled markers.
+- Severity scaling: `Math.abs(goldsteinScore) / 10 * maxSize` for proportional sizing.
+
+### ARG-029: Incident detail panel with metadata
+
+| | |
+|---|---|
+| **Type** | Feature |
+| **Priority** | **P1** |
+| **Labels** | frontend, ui, tdd, sprint-6 |
+| **Estimate** | 3–4 hours |
+| **Depends On** | ARG-028 |
+| **PRD Ref** | PRD Section 5.1 — Incident Detail Panel |
+
+**Description**
+
+When a user clicks an incident marker, display a detail panel with incident metadata and a loading state for news articles.
+
+**Acceptance Criteria**
+
+- GIVEN incidents are on the globe, WHEN I click an incident marker, THEN a detail panel opens showing: category (with colored badge), title/description, severity (Goldstein score with visual indicator), event date, actors involved, and source URL link.
+- GIVEN the panel is open, WHEN news articles are loading, THEN a loading skeleton/spinner is shown in the news section.
+- GIVEN the panel is open, WHEN I click close or click empty globe space, THEN the panel closes.
+- The incident panel and flight panel share the same panel component with different content (or the same panel area, replacing content).
+- Component tests: panel renders with mock incident data, loading state displays correctly.
+
+### ARG-030: News articles list in incident detail panel
+
+| | |
+|---|---|
+| **Type** | Feature |
+| **Priority** | **P1** |
+| **Labels** | frontend, ui, tdd, sprint-6 |
+| **Estimate** | 3–4 hours |
+| **Depends On** | ARG-029 |
+| **PRD Ref** | PRD Section 5.1 — News Integration |
+
+**Description**
+
+Fetch and display related news articles when an incident is selected, using the `/api/v1/incidents/{id}/news` endpoint.
+
+**Acceptance Criteria**
+
+- GIVEN an incident panel is open, WHEN the news data loads, THEN up to 10 articles are displayed below the incident metadata.
+- Each article shows: headline (clickable link to original), source name, publication date (relative, e.g., "2 hours ago"), and tone indicator (positive/negative/neutral).
+- GIVEN the news API returns an error, WHEN the panel is open, THEN a friendly error message is shown ("Unable to load related articles") with a retry button.
+- GIVEN the news API returns 0 articles, THEN a "No related articles found" message is displayed.
+- Links open in a new browser tab (`target="_blank"`).
+- Component tests: article list renders, empty state renders, error state renders.
+
+### ARG-031: Event filter bar UI
+
+| | |
+|---|---|
+| **Type** | Feature |
+| **Priority** | **P2** |
+| **Labels** | frontend, ui, tdd, sprint-6 |
+| **Estimate** | 2–3 hours |
+| **Depends On** | ARG-027, ARG-028 |
+| **PRD Ref** | PRD Section 5.1 — Event Filtering |
+
+**Description**
+
+Create a filter bar overlay on the globe that allows users to toggle incident categories on/off and adjust the severity threshold.
+
+**Acceptance Criteria**
+
+- A filter bar appears at the top or side of the globe with toggle buttons for each incident category (Conflict, Disaster, Political, Infrastructure).
+- Each toggle shows the category color and can be turned on/off.
+- A severity slider allows adjusting the minimum severity threshold.
+- GIVEN I toggle off "Conflict", WHEN the globe updates, THEN conflict incidents are hidden.
+- GIVEN I slide severity to high-only, WHEN the globe updates, THEN low-severity incidents are hidden.
+- Filter state persists during the session (not across sessions for MVP).
+- Component tests: filter toggles work, severity slider updates state.
+
+---
+
+## Sprint 7: Polish, Integration Testing, and Documentation
+
+**Goal:** *End-to-end verification, performance tuning, error states, loading states, and final documentation for a demo-ready MVP.*
+
+**Duration:** 3–4 days | Tickets: 5 | P0 blockers: 1
+
+| ID | Title | Priority | Type | Estimate |
+|---|---|---|---|---|
+| **ARG-032** | Loading states and error boundaries | **P1** | Feature | 2–3 hours |
+| **ARG-033** | Performance optimization for high marker counts | **P1** | Task | 3–4 hours |
+| **ARG-034** | README with architecture diagrams and setup instructions | **P1** | Documentation | 3–4 hours |
+| **ARG-035** | End-to-end smoke test with live APIs | **P0** | Task | 2–3 hours |
+| **ARG-036** | Mock data generator for demos and testing | **P2** | Feature | 2–3 hours |
+
+### ARG-032: Loading states and error boundaries
+
+| | |
+|---|---|
+| **Type** | Feature |
+| **Priority** | **P1** |
+| **Labels** | frontend, ui, sprint-7 |
+| **Estimate** | 2–3 hours |
+| **Depends On** | ARG-025, ARG-028 |
+| **PRD Ref** | PRD Section 10 — Success Metrics |
+
+**Description**
+
+Add polished loading states for initial globe load, data fetching, and error scenarios.
+
+**Acceptance Criteria**
+
+- GIVEN the app is loading for the first time, WHEN the globe is initializing, THEN a centered loading spinner with "Loading Argus..." is displayed.
+- GIVEN the backend is unreachable, WHEN the frontend fails to fetch data, THEN a non-intrusive error banner appears ("Unable to reach Argus server. Retrying...") without blocking the globe.
+- A React Error Boundary wraps the app to catch rendering errors and display a fallback UI.
+- GIVEN the backend recovers, WHEN the next poll succeeds, THEN the error banner auto-dismisses.
+
+### ARG-033: Performance optimization for high marker counts
+
+| | |
+|---|---|
+| **Type** | Task |
+| **Priority** | **P1** |
+| **Labels** | frontend, performance, sprint-7 |
+| **Estimate** | 3–4 hours |
+| **Depends On** | ARG-025, ARG-028 |
+| **PRD Ref** | PRD Section 11 — Risks and Mitigations |
+
+**Description**
+
+Profile and optimize Globe.gl rendering when thousands of flight markers are visible. Implement marker clustering or viewport-based rendering if needed.
+
+**Acceptance Criteria**
+
+- GIVEN 5000 flight markers are loaded, WHEN the globe renders at full zoom-out, THEN frame rate stays above 30fps.
+- If marker count exceeds a threshold (configurable, default 2000), markers at low zoom levels are clustered or simplified (e.g., switch from HTML elements to WebGL points).
+- Performance is measured and documented (Chrome DevTools Performance recording included in PR).
+
+### ARG-034: README with architecture diagrams and setup instructions
+
+| | |
+|---|---|
+| **Type** | Documentation |
+| **Priority** | **P1** |
+| **Labels** | documentation, sprint-7 |
+| **Estimate** | 3–4 hours |
+| **Depends On** | All previous tickets |
+| **PRD Ref** | Documentation roadmap |
+
+**Description**
+
+Write a comprehensive README.md that serves as the project's landing page on GitHub. This is the first thing a recruiter sees.
+
+**Acceptance Criteria**
+
+- README includes: project name and tagline, hero screenshot or GIF of the globe in action, problem statement (2-3 sentences), tech stack with version numbers, architecture diagram (embedded SVG or image), features list (MVP), prerequisites and setup instructions (step-by-step), how to run tests, API documentation link (Swagger), project structure overview, testing methodology note, license.
+- Setup instructions work on a fresh machine with only Docker, JDK 17, and Node 18 installed.
+- README renders correctly on GitHub (no broken images, proper markdown).
+
+### ARG-035: End-to-end smoke test with live APIs
+
+| | |
+|---|---|
+| **Type** | Task |
+| **Priority** | **P0** |
+| **Labels** | testing, integration, sprint-7 |
+| **Estimate** | 2–3 hours |
+| **Depends On** | All feature tickets |
+| **PRD Ref** | PRD Section 10 — Success Metrics |
+
+**Description**
+
+Manually verify the full system end-to-end with live external APIs. Document any issues and fix blockers.
+
+**Acceptance Criteria**
+
+- Start PostgreSQL via Docker Compose, backend via `./mvnw spring-boot:run`, frontend via `npm run dev`.
+- Globe loads within 3 seconds.
+- Flight markers appear within 30 seconds (first poll cycle).
+- Incident markers appear within 1 minute (first GDELT poll).
+- Clicking a flight opens the detail panel with correct data.
+- Clicking an incident opens the detail panel with metadata.
+- News articles load when an incident is selected.
+- Event filters correctly show/hide incident categories.
+- All backend tests pass: `./mvnw test`.
+- All frontend tests pass: `npm test`.
+- No console errors in browser DevTools.
+
+### ARG-036: Mock data generator for demos and testing
+
+| | |
+|---|---|
+| **Type** | Feature |
+| **Priority** | **P2** |
+| **Labels** | backend, testing, sprint-7 |
+| **Estimate** | 2–3 hours |
+| **Depends On** | ARG-007, ARG-008 |
+| **PRD Ref** | ADR-006 — Consequences (mock data for demos) |
+
+**Description**
+
+Create a data seeder that populates the database with realistic mock flights and incidents for demos when external APIs are unavailable or rate-limited.
+
+**Acceptance Criteria**
+
+- A Spring profile (`demo`) seeds the database with: 200 mock flights spread across major flight routes, 15 mock incidents of varied categories and severities across different regions, 5 mock news articles per incident.
+- GIVEN the app starts with `--spring.profiles.active=demo`, WHEN I open the globe, THEN I see a populated, impressive-looking demo without any external API calls.
+- Mock data is realistic (flight paths over known routes, incidents in plausible locations with real-sounding descriptions).
+
+---
+
+## Appendix: Critical Path
+
+The critical path through the MVP determines the minimum calendar time to completion. The longest sequential dependency chain is:
+
+**ARG-001** (Spring Boot init) → **ARG-004** (Flyway schema) → **ARG-007/008** (Entities) → **ARG-014** (Filter pipeline) → **ARG-018** (Incident poller) → **ARG-020** (Incident API) → **ARG-028** (Incident markers) → **ARG-035** (E2E smoke test)
+
+This chain spans all 7 sprints. The frontend work (Sprints 5-6) can be partially parallelized with late Sprint 3 and Sprint 4 backend work by using mock API responses during frontend development.
+
+**Estimated total calendar time:** 26–33 days of focused development (assuming full-time effort).


### PR DESCRIPTION
…log)

## Summary

Add all four project planning documents converted from .docx to Markdown for GitHub rendering.
Cross-document links are wired up. README doc links now resolve correctly.

## Type of Change

- [X] `docs` — Documentation only

## What Changed

- Added `docs/Argus_PRD_v1_0.md`
- Added `docs/Argus_ADRs_v1_0.md`
- Added `docs/Argus_Architecture_v1_0.md`
- Added `docs/Argus_Sprint_Backlog_v1_0.md`

## Testing

- [x] Manual verification completed

## Checklist

- [x] Commit messages follow conventional commits format
- [x] No secrets or credentials committed