### PR TITLE
feat(ARG-004): add Flyway initial schema migration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ docker-compose down
 ### Backend
 ```bash
 ./mvnw spring-boot:run
+SPRING_PROFILES_ACTIVE=dev ./mvnw spring-boot:run
 ./mvnw test
 ./mvnw clean package
 ./mvnw spotless:check
@@ -53,6 +54,12 @@ Database verification for ARG-003:
 2. `docker-compose up -d db`
 3. `docker-compose ps`
 4. `docker-compose exec db psql -U argus_user -d argus -c "SELECT PostGIS_Version();"`
+
+Schema verification for ARG-004:
+1. `cp .env.example .env`
+2. `docker-compose up -d db`
+3. `SPRING_PROFILES_ACTIVE=dev ./mvnw spring-boot:run`
+4. `./scripts/verify_arg004_schema.sh`
 
 Important local URLs:
 - Frontend: `http://localhost:5173`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,4 +14,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial interactive globe UI with a dark Argus landing layout and Earth texture rendering
 - Frontend API client scaffold and Vite dev proxy for backend requests during local development
 - Local PostgreSQL 16 + PostGIS 3.4 Docker Compose setup with persistent data storage and verification steps
+- Initial Flyway schema migration for flights, incidents, and news_articles with PostGIS-enabled geometry columns and indexes
 - Shared repository contributor guidance in `AGENTS.md`

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ docker-compose up -d db
 docker-compose exec db psql -U argus_user -d argus -c "SELECT PostGIS_Version();"
 
 # 4. Start the backend
-./mvnw spring-boot:run
+SPRING_PROFILES_ACTIVE=dev ./mvnw spring-boot:run
 
 # 5. Start the frontend (in a new terminal)
 cd frontend
@@ -96,6 +96,27 @@ Expected result:
 - the `db` container is running and healthy
 - PostgreSQL is reachable on `localhost:5432`
 - `SELECT PostGIS_Version();` returns a PostGIS `3.4.x` version
+
+### Verifying Flyway Schema Initialization
+
+After the database is running, start the backend with the `dev` profile so Flyway
+applies the initial migration:
+
+```bash
+SPRING_PROFILES_ACTIVE=dev ./mvnw spring-boot:run
+```
+
+Then, in a separate terminal, verify the schema created by `V1__init.sql`:
+
+```bash
+./scripts/verify_arg004_schema.sh
+```
+
+Expected result:
+- `public.flights`, `public.incidents`, and `public.news_articles` exist
+- `flights.location` and `incidents.location` use `geometry(Point,4326)`
+- the required GiST and B-tree indexes are present
+- `news_articles.incident_id` references `incidents.id`
 
 ### Running Tests
 

--- a/scripts/verify_arg004_schema.sh
+++ b/scripts/verify_arg004_schema.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+POSTGRES_DB="${POSTGRES_DB:-argus}"
+POSTGRES_USER="${POSTGRES_USER:-argus_user}"
+COMPOSE_CMD="${COMPOSE_CMD:-docker compose}"
+
+echo "Checking database tables..."
+$COMPOSE_CMD exec db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c '\dt'
+
+echo
+echo "Describing flights table..."
+$COMPOSE_CMD exec db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c '\d flights'
+
+echo
+echo "Describing incidents table..."
+$COMPOSE_CMD exec db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c '\d incidents'
+
+echo
+echo "Describing news_articles table..."
+$COMPOSE_CMD exec db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c '\d news_articles'
+
+echo
+echo "Checking PostGIS extension version..."
+$COMPOSE_CMD exec db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c 'SELECT PostGIS_Version();'

--- a/scripts/verify_arg004_schema.sh
+++ b/scripts/verify_arg004_schema.sh
@@ -7,7 +7,7 @@ POSTGRES_USER="${POSTGRES_USER:-argus_user}"
 COMPOSE_CMD="${COMPOSE_CMD:-docker compose}"
 
 echo "Checking database tables..."
-$COMPOSE_CMD exec db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c '\dt'
+$COMPOSE_CMD exec db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c '\dt public.*'
 
 echo
 echo "Describing flights table..."

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,8 @@
 # =============================================================================
 # Argus — Application Configuration
-# Default section: no database required (DataSource/JPA/Flyway excluded).
-# Activate the "dev" profile (SPRING_PROFILES_ACTIVE=dev) when Docker DB is up.
+# Default section keeps DB-dependent autoconfiguration off for non-database tasks.
+# Activate the "dev" profile (SPRING_PROFILES_ACTIVE=dev) to connect to the
+# local PostgreSQL + PostGIS container and apply Flyway migrations on startup.
 # =============================================================================
 server:
   port: 8080
@@ -10,8 +11,8 @@ spring:
   application:
     name: argus
 
-  # Exclude DB-dependent autoconfiguration until the database is provisioned
-  # (ARG-003 / ARG-004). Remove these exclusions once Flyway migrations land.
+  # Leave DB-dependent autoconfiguration off by default so documentation work,
+  # frontend work, and non-DB backend tests can still boot cleanly.
   autoconfigure:
     exclude:
       - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
@@ -39,14 +40,14 @@ logging:
 
 ---
 # =============================================================================
-# dev profile — requires docker-compose up -d db
+# dev profile — requires the local PostgreSQL + PostGIS container from ARG-003
 # =============================================================================
 spring:
   config:
     activate:
       on-profile: dev
 
-  # Re-enable autoconfiguration excluded in the default section
+  # Re-enable the database stack for local development.
   autoconfigure:
     exclude: []
 
@@ -76,14 +77,14 @@ logging:
 
 ---
 # =============================================================================
-# prod profile
+# prod profile — enables the same Flyway-managed schema flow against deployment DBs
 # =============================================================================
 spring:
   config:
     activate:
       on-profile: prod
 
-  # Re-enable autoconfiguration excluded in the default section
+  # Re-enable the database stack for production.
   autoconfigure:
     exclude: []
 

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,62 @@
+CREATE EXTENSION IF NOT EXISTS postgis;
+
+CREATE TABLE flights (
+    icao24 VARCHAR(16) PRIMARY KEY,
+    callsign VARCHAR(32),
+    origin_country VARCHAR(128),
+    location geometry(Point, 4326) NOT NULL,
+    altitude DOUBLE PRECISION,
+    velocity DOUBLE PRECISION,
+    heading DOUBLE PRECISION,
+    vertical_rate DOUBLE PRECISION,
+    on_ground BOOLEAN NOT NULL DEFAULT FALSE,
+    last_seen TIMESTAMP NOT NULL
+);
+
+CREATE TABLE incidents (
+    id BIGSERIAL PRIMARY KEY,
+    gdelt_id BIGINT NOT NULL,
+    category VARCHAR(64) NOT NULL,
+    title VARCHAR(512) NOT NULL,
+    goldstein_score DOUBLE PRECISION NOT NULL,
+    location geometry(Point, 4326) NOT NULL,
+    event_date TIMESTAMP NOT NULL,
+    actors TEXT,
+    source_url TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE news_articles (
+    id BIGSERIAL PRIMARY KEY,
+    incident_id BIGINT NOT NULL,
+    title VARCHAR(512) NOT NULL,
+    source VARCHAR(255) NOT NULL,
+    url TEXT NOT NULL,
+    published_at TIMESTAMP,
+    tone DOUBLE PRECISION,
+    fetched_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_news_articles_incident
+        FOREIGN KEY (incident_id)
+        REFERENCES incidents (id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX idx_flights_location_gist
+    ON flights
+    USING GIST (location);
+
+CREATE INDEX idx_incidents_location_gist
+    ON incidents
+    USING GIST (location);
+
+CREATE INDEX idx_flights_last_seen
+    ON flights (last_seen);
+
+CREATE INDEX idx_incidents_category
+    ON incidents (category);
+
+CREATE INDEX idx_incidents_event_date
+    ON incidents (event_date);
+
+CREATE INDEX idx_news_articles_incident_id
+    ON news_articles (incident_id);


### PR DESCRIPTION
## Summary

Closes #5 by configuring the initial Flyway-managed database schema for Argus. This adds the first migration for the core application tables, enables PostGIS-backed geometry columns, and documents the local verification flow for schema initialization.

## Type of Change

- [x] `feat` — New feature

## What Changed

Implemented the initial Flyway migration required for `ARG-004`.

Key changes:
- Added `V1__init.sql` under `src/main/resources/db/migration/`
- Enabled the initial schema through Flyway-managed startup in the existing backend configuration
- Created the core database tables:
  - `flights`
  - `incidents`
  - `news_articles`
- Enabled the PostGIS extension in the migration with:
  - `CREATE EXTENSION IF NOT EXISTS postgis;`
- Added `geometry(Point, 4326)` columns for:
  - `flights.location`
  - `incidents.location`
- Added the required primary key and foreign key constraints
- Added the required indexes:
  - GiST indexes on `flights.location` and `incidents.location`
  - B-tree indexes on:
    - `flights.last_seen`
    - `incidents.category`
    - `incidents.event_date`
    - `news_articles.incident_id`
- Added a local verification helper script:
  - `scripts/verify_arg004_schema.sh`
- Updated project documentation to show how to:
  - start the DB
  - run the backend with the `dev` profile
  - verify the created schema and PostGIS version
- Updated the changelog to reflect the initial Flyway schema milestone

## Testing

- [ ] Unit tests written (TDD — tests were written first)
- [ ] Integration tests written/updated
- [x] All existing tests pass (`./mvnw test` / `npm test`)
- [ ] Coverage meets threshold (>80% backend / >70% frontend)
- [x] Manual verification completed

Automated verification:
- Ran `./mvnw test`

Manual verification:
- Ran `docker compose up -d db`
- Ran `SPRING_PROFILES_ACTIVE=dev ./mvnw spring-boot:run`
- Ran `./scripts/verify_arg004_schema.sh`
- Verified:
  - `public.flights` exists
  - `public.incidents` exists
  - `public.news_articles` exists
  - `flights.location` is `geometry(Point,4326)`
  - `incidents.location` is `geometry(Point,4326)`
  - required GiST and B-tree indexes are present
  - `news_articles.incident_id` references `incidents.id`
  - `SELECT PostGIS_Version();` returns a PostGIS `3.4.x` version

## Screenshots

<img width="577" height="781" alt="arg-004-script-output" src="https://github.com/user-attachments/assets/2da2a2bf-0210-4826-8fd8-e13475e9483d" />

If applicable, add screenshots or GIFs demonstrating the change.

## Checklist

- [x] Code follows project conventions
- [x] Commit messages follow conventional commits format
- [x] No secrets or credentials committed
- [x] CHANGELOG.md updated (if user-facing change)
- [ ] Swagger/OpenAPI docs updated (if API change)
