### PR TITLE
feat(ARG-006): configure CORS and Spring application profiles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,16 +15,17 @@ Current status:
 
 ### Infrastructure
 ```bash
-docker-compose up -d db
-docker-compose ps
-docker-compose exec db psql -U argus_user -d argus -c "SELECT PostGIS_Version();"
-docker-compose down
+docker compose up -d db
+docker compose ps
+docker compose exec db psql -U argus_user -d argus -c "SELECT PostGIS_Version();"
+docker compose down
 ```
 
 ### Backend
 ```bash
+source ./scripts/use-java17.sh
+export SPRING_PROFILES_ACTIVE=dev
 ./mvnw spring-boot:run
-SPRING_PROFILES_ACTIVE=dev ./mvnw spring-boot:run
 ./mvnw test
 ./mvnw clean package
 ./mvnw spotless:check
@@ -45,25 +46,53 @@ npm run format
 ## Local Development
 
 Run the project in three terminals:
-1. `docker-compose up -d db`
-2. `./mvnw spring-boot:run`
+1. `docker compose up -d db`
+2. `source ./scripts/use-java17.sh && export SPRING_PROFILES_ACTIVE=dev && ./mvnw spring-boot:run`
 3. `cd frontend && npm install && npm run dev`
+
+Backend terminal checklist:
+1. `source ./scripts/use-java17.sh`
+2. `export SPRING_PROFILES_ACTIVE=dev`
+3. `docker compose up -d db`
+4. `./mvnw spring-boot:run`
+
+Why this matters:
+- `use-java17.sh` sets the required local JDK for this repository.
+- The `dev` profile enables the local PostgreSQL connection, Flyway, debug logging, and dev-only CORS for `http://localhost:5173`.
+- If you open a new terminal tab, rerun the `source` and `export` commands in that new shell.
 
 Database verification for ARG-003:
 1. `cp .env.example .env`
-2. `docker-compose up -d db`
-3. `docker-compose ps`
-4. `docker-compose exec db psql -U argus_user -d argus -c "SELECT PostGIS_Version();"`
+2. `docker compose up -d db`
+3. `docker compose ps`
+4. `docker compose exec db psql -U argus_user -d argus -c "SELECT PostGIS_Version();"`
 
 Schema verification for ARG-004:
 1. `cp .env.example .env`
-2. `docker-compose up -d db`
-3. `SPRING_PROFILES_ACTIVE=dev ./mvnw spring-boot:run`
-4. `./scripts/verify_arg004_schema.sh`
+2. `docker compose up -d db`
+3. `source ./scripts/use-java17.sh`
+4. `export SPRING_PROFILES_ACTIVE=dev`
+5. `./mvnw spring-boot:run`
+6. `./scripts/verify_arg004_schema.sh`
+
+Profile and CORS verification for ARG-006:
+1. `source ./scripts/use-java17.sh`
+2. `export SPRING_PROFILES_ACTIVE=dev`
+3. `docker compose up -d db`
+4. `./mvnw test`
+5. `./mvnw spring-boot:run`
+6. `curl -i -H "Origin: http://localhost:5173" http://localhost:8080/api/v1/health`
+7. `curl -i -H "Origin: http://localhost:3000" http://localhost:8080/api/v1/health`
+
+Expected result:
+- allowed origin returns `200` with `Access-Control-Allow-Origin: http://localhost:5173`
+- unconfigured origin returns `403 Invalid CORS request`
 
 Important local URLs:
 - Frontend: `http://localhost:5173`
 - Backend API: `http://localhost:8080`
+- Health endpoint: `http://localhost:8080/api/v1/health`
+- OpenAPI JSON: `http://localhost:8080/api-docs`
 - Swagger UI: `http://localhost:8080/swagger-ui.html`
 
 ## Architecture
@@ -116,6 +145,11 @@ OPENSKY_USERNAME=...
 OPENSKY_PASSWORD=...
 SPRING_PROFILES_ACTIVE=dev
 ```
+
+Profile notes:
+- `default` boots the backend without a database for lightweight tasks.
+- `dev` is the normal local development profile.
+- `prod` is reserved for deployed environments with env-driven DB settings.
 
 ## Development Conventions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial Flyway schema migration for flights, incidents, and news_articles with PostGIS-enabled geometry columns and indexes
 - GitHub Actions CI workflow that runs backend and frontend tests and uploads coverage artifacts
 - Shared repository contributor guidance in `AGENTS.md`
+- Dev and prod Spring profile files with environment-specific polling, logging, and database settings
+- Dev-only CORS configuration that allows the Vite frontend origin at `http://localhost:5173`
+- Local Java 17 helper script and documented backend startup flow for profile-aware development

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,11 +14,21 @@
 ```
 1. git checkout develop && git pull
 2. git checkout -b feature/ARG-XXX-short-description
-3. Write tests → implement → refactor (TDD)
-4. git commit using conventional commits (see below)
-5. git push -u origin feature/ARG-XXX-short-description
-6. Open PR targeting develop
-7. CI must pass before merge
+3. source ./scripts/use-java17.sh && export SPRING_PROFILES_ACTIVE=dev
+4. Write tests → implement → refactor (TDD)
+5. git commit using conventional commits (see below)
+6. git push -u origin feature/ARG-XXX-short-description
+7. Open PR targeting develop
+8. CI must pass before merge
+```
+
+For local backend work, keep this startup flow handy:
+
+```bash
+source ./scripts/use-java17.sh
+export SPRING_PROFILES_ACTIVE=dev
+docker compose up -d db
+./mvnw spring-boot:run
 ```
 
 ## Commit Messages

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Argus visualizes live air traffic, geopolitical incidents, and world events on a
 <!-- TODO: Replace with hero screenshot or GIF after Sprint 5 -->
 <!-- ![Argus Globe](docs/images/argus-hero.png) -->
 
-> 🚧 **Status: Actively under development** — see the [Changelog](CHANGELOG.md) for progress.
+> **STATUS: Actively under development** — see the [Changelog](CHANGELOG.md) for progress.
 
 ---
 
@@ -64,15 +64,19 @@ cp .env.example .env
 # Edit .env with your OpenSky credentials and database password
 
 # 3. Start the database
-docker-compose up -d db
+docker compose up -d db
 
 # 3a. Verify PostGIS is available
-docker-compose exec db psql -U argus_user -d argus -c "SELECT PostGIS_Version();"
+docker compose exec db psql -U argus_user -d argus -c "SELECT PostGIS_Version();"
 
-# 4. Start the backend
-SPRING_PROFILES_ACTIVE=dev ./mvnw spring-boot:run
+# 4. Configure the backend shell
+source ./scripts/use-java17.sh
+export SPRING_PROFILES_ACTIVE=dev
 
-# 5. Start the frontend (in a new terminal)
+# 5. Start the backend
+./mvnw spring-boot:run
+
+# 6. Start the frontend (in a new terminal)
 cd frontend
 npm install
 npm run dev
@@ -82,14 +86,25 @@ Open [http://localhost:5173](http://localhost:5173) to see the globe.
 
 API documentation is available at [http://localhost:8080/swagger-ui.html](http://localhost:8080/swagger-ui.html) when the backend is running.
 
+If you open a new terminal tab for backend work later, rerun:
+
+```bash
+source ./scripts/use-java17.sh
+export SPRING_PROFILES_ACTIVE=dev
+```
+
+The `dev` profile is the normal local development mode. It enables the local
+PostgreSQL connection, Flyway migrations, debug logging, and the dev-only CORS
+rule that allows the frontend at `http://localhost:5173` to call the backend.
+
 ### Verifying PostgreSQL + PostGIS
 
 Use these commands to validate the local database setup after copying `.env.example` to `.env`:
 
 ```bash
-docker-compose up -d db
-docker-compose ps
-docker-compose exec db psql -U argus_user -d argus -c "SELECT PostGIS_Version();"
+docker compose up -d db
+docker compose ps
+docker compose exec db psql -U argus_user -d argus -c "SELECT PostGIS_Version();"
 ```
 
 Expected result:
@@ -103,7 +118,9 @@ After the database is running, start the backend with the `dev` profile so Flywa
 applies the initial migration:
 
 ```bash
-SPRING_PROFILES_ACTIVE=dev ./mvnw spring-boot:run
+source ./scripts/use-java17.sh
+export SPRING_PROFILES_ACTIVE=dev
+./mvnw spring-boot:run
 ```
 
 Then, in a separate terminal, verify the schema created by `V1__init.sql`:
@@ -117,6 +134,20 @@ Expected result:
 - `flights.location` and `incidents.location` use `geometry(Point,4326)`
 - the required GiST and B-tree indexes are present
 - `news_articles.incident_id` references `incidents.id`
+
+### Verifying Local CORS and Profiles
+
+With the backend running under the `dev` profile:
+
+```bash
+curl -i -H "Origin: http://localhost:5173" http://localhost:8080/api/v1/health
+curl -i -H "Origin: http://localhost:3000" http://localhost:8080/api/v1/health
+```
+
+Expected result:
+- `http://localhost:5173` returns `200` and includes `Access-Control-Allow-Origin: http://localhost:5173`
+- `http://localhost:3000` returns `403 Invalid CORS request`
+- the Spring Boot logs show `The following 1 profile is active: "dev"`
 
 ### Running Tests
 

--- a/docs/Argus_Architecture_v1_0.md
+++ b/docs/Argus_Architecture_v1_0.md
@@ -219,6 +219,11 @@ Sensitive values are stored in a `.env` file (gitignored) and referenced in `app
 - `POSTGRES_USER` / `POSTGRES_PASSWORD` — Database credentials.
 - `SPRING_PROFILES_ACTIVE` — `dev` (local) or `prod` (deployed). Controls logging level and polling intervals.
 
+Profile behavior:
+- `application.yml` contains shared defaults and disables DB-dependent autoconfiguration when no profile is set.
+- `application-dev.yml` enables the local PostgreSQL connection, Flyway, debug logging, relaxed poll intervals, and CORS for `http://localhost:5173`.
+- `application-prod.yml` enables env-driven database settings, production poll intervals, and info-level logging.
+
 ## 7. Cross-Cutting Concerns
 
 ### 7.1 Error handling and resilience
@@ -236,7 +241,8 @@ Sensitive values are stored in a `.env` file (gitignored) and referenced in `app
 ### 7.3 Security (MVP scope)
 
 - No authentication for MVP — the application runs locally and is not exposed to the internet.
-- CORS configured to allow localhost origins only.
+- In the `dev` profile, CORS is configured to allow `http://localhost:5173` and reject unconfigured origins.
+- The `prod` profile does not enable the dev-only localhost CORS rule.
 - OpenSky credentials stored in `.env` file, never committed to version control.
 - Post-MVP: Spring Security with JWT authentication will be added when user accounts are implemented.
 

--- a/scripts/use-java17.sh
+++ b/scripts/use-java17.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+JAVA17_HOME=$(/usr/libexec/java_home -v 17 2>/dev/null) || {
+  echo "Java 17 was not found on this machine." >&2
+  return 1 2>/dev/null || exit 1
+}
 
-export JAVA_HOME=$(/usr/libexec/java_home -v 17)
+export JAVA_HOME="$JAVA17_HOME"
 export PATH="$JAVA_HOME/bin:$PATH"
 
 echo "Argus shell configured for Java 17"

--- a/src/main/java/com/argus/config/DevCorsConfig.java
+++ b/src/main/java/com/argus/config/DevCorsConfig.java
@@ -1,0 +1,27 @@
+package com.argus.config;
+
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@Profile("dev")
+public class DevCorsConfig implements WebMvcConfigurer {
+
+    private final List<String> allowedOrigins;
+
+    public DevCorsConfig(@Value("${argus.cors.allowed-origins}") List<String> allowedOrigins) {
+        this.allowedOrigins = allowedOrigins;
+    }
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins(allowedOrigins.toArray(String[]::new))
+                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+                .allowedHeaders("*");
+    }
+}

--- a/src/main/java/com/argus/config/DevCorsConfig.java
+++ b/src/main/java/com/argus/config/DevCorsConfig.java
@@ -1,7 +1,7 @@
 package com.argus.config;
 
 import java.util.List;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
@@ -9,12 +9,13 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 @Profile("dev")
+@EnableConfigurationProperties(DevCorsProperties.class)
 public class DevCorsConfig implements WebMvcConfigurer {
 
     private final List<String> allowedOrigins;
 
-    public DevCorsConfig(@Value("${argus.cors.allowed-origins}") List<String> allowedOrigins) {
-        this.allowedOrigins = allowedOrigins;
+    public DevCorsConfig(DevCorsProperties corsProperties) {
+        this.allowedOrigins = corsProperties.getAllowedOrigins();
     }
 
     @Override

--- a/src/main/java/com/argus/config/DevCorsProperties.java
+++ b/src/main/java/com/argus/config/DevCorsProperties.java
@@ -1,0 +1,19 @@
+package com.argus.config;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "argus.cors")
+public class DevCorsProperties {
+
+    private List<String> allowedOrigins = new ArrayList<>();
+
+    public List<String> getAllowedOrigins() {
+        return allowedOrigins;
+    }
+
+    public void setAllowedOrigins(List<String> allowedOrigins) {
+        this.allowedOrigins = allowedOrigins;
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,39 @@
+# =============================================================================
+# Argus — Development Profile
+# Local development uses the Docker PostgreSQL + PostGIS container and slower
+# polling intervals to keep the app easier to run while building features.
+# =============================================================================
+spring:
+  autoconfigure:
+    exclude: []
+
+  datasource:
+    url: jdbc:postgresql://localhost:5432/${POSTGRES_DB:argus}
+    username: ${POSTGRES_USER:argus_user}
+    password: ${POSTGRES_PASSWORD:changeme}
+    driver-class-name: org.postgresql.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+
+argus:
+  polling:
+    flights:
+      interval: 60s
+    incidents:
+      interval: 30m
+
+logging:
+  level:
+    com.argus: DEBUG
+    org.springframework.web: DEBUG
+    org.hibernate.SQL: DEBUG

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -26,6 +26,9 @@ spring:
     locations: classpath:db/migration
 
 argus:
+  cors:
+    allowed-origins:
+      - http://localhost:5173
   polling:
     flights:
       interval: 60s

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,44 @@
+# =============================================================================
+# Argus — Production Profile
+# Production uses environment-driven database settings and standard polling
+# intervals suitable for live deployments.
+# =============================================================================
+spring:
+  autoconfigure:
+    exclude: []
+
+  datasource:
+    url: ${DATABASE_URL}
+    username: ${POSTGRES_USER}
+    password: ${POSTGRES_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    show-sql: false
+
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,metrics
+  endpoint:
+    health:
+      show-details: never
+
+argus:
+  polling:
+    flights:
+      interval: 15s
+    incidents:
+      interval: 15m
+
+logging:
+  level:
+    com.argus: INFO
+    root: WARN

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,8 +1,8 @@
 # =============================================================================
-# Argus — Application Configuration
-# Default section keeps DB-dependent autoconfiguration off for non-database tasks.
-# Activate the "dev" profile (SPRING_PROFILES_ACTIVE=dev) to connect to the
-# local PostgreSQL + PostGIS container and apply Flyway migrations on startup.
+# Argus — Shared Application Configuration
+# Profile-specific settings live in application-dev.yml and application-prod.yml.
+# Keep DB-dependent autoconfiguration off by default so docs work, frontend work,
+# and non-DB backend tests can still boot cleanly without a database.
 # =============================================================================
 server:
   port: 8080
@@ -33,86 +33,3 @@ springdoc:
     path: /api-docs
   swagger-ui:
     path: /swagger-ui.html
-
-logging:
-  level:
-    com.argus: DEBUG
-
----
-# =============================================================================
-# dev profile — requires the local PostgreSQL + PostGIS container from ARG-003
-# =============================================================================
-spring:
-  config:
-    activate:
-      on-profile: dev
-
-  # Re-enable the database stack for local development.
-  autoconfigure:
-    exclude: []
-
-  datasource:
-    url: jdbc:postgresql://localhost:5432/${POSTGRES_DB:argus}
-    username: ${POSTGRES_USER:argus_user}
-    password: ${POSTGRES_PASSWORD:changeme}
-    driver-class-name: org.postgresql.Driver
-
-  jpa:
-    hibernate:
-      ddl-auto: validate
-    show-sql: true
-    properties:
-      hibernate:
-        format_sql: true
-
-  flyway:
-    enabled: true
-    locations: classpath:db/migration
-
-logging:
-  level:
-    com.argus: DEBUG
-    org.springframework.web: DEBUG
-    org.hibernate.SQL: DEBUG
-
----
-# =============================================================================
-# prod profile — enables the same Flyway-managed schema flow against deployment DBs
-# =============================================================================
-spring:
-  config:
-    activate:
-      on-profile: prod
-
-  # Re-enable the database stack for production.
-  autoconfigure:
-    exclude: []
-
-  datasource:
-    url: ${DATABASE_URL}
-    username: ${POSTGRES_USER}
-    password: ${POSTGRES_PASSWORD}
-    driver-class-name: org.postgresql.Driver
-
-  jpa:
-    hibernate:
-      ddl-auto: validate
-    show-sql: false
-
-  flyway:
-    enabled: true
-    locations: classpath:db/migration
-
-management:
-  endpoints:
-    web:
-      exposure:
-        include: health,metrics
-  endpoint:
-    health:
-      show-details: never
-
-logging:
-  level:
-    com.argus: INFO
-    root: WARN

--- a/src/test/java/com/argus/config/DevCorsConfigTest.java
+++ b/src/test/java/com/argus/config/DevCorsConfigTest.java
@@ -1,0 +1,41 @@
+package com.argus.config;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.argus.controller.HealthController;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(HealthController.class)
+@Import(DevCorsConfig.class)
+@ActiveProfiles("dev")
+@TestPropertySource(properties = "argus.cors.allowed-origins=http://localhost:5173")
+class DevCorsConfigTest {
+
+    @Autowired private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("Dev profile allows requests from the frontend dev server origin")
+    void devProfile_allowsFrontendDevServerOrigin() throws Exception {
+        mockMvc.perform(get("/api/v1/health").header("Origin", "http://localhost:5173"))
+                .andExpect(status().isOk())
+                .andExpect(
+                        header().string("Access-Control-Allow-Origin", "http://localhost:5173"));
+    }
+
+    @Test
+    @DisplayName("Dev profile does not allow unconfigured origins")
+    void devProfile_rejectsUnconfiguredOrigin() throws Exception {
+        mockMvc.perform(get("/api/v1/health").header("Origin", "http://localhost:3000"))
+                .andExpect(status().isForbidden())
+                .andExpect(header().doesNotExist("Access-Control-Allow-Origin"));
+    }
+}

--- a/src/test/java/com/argus/config/ProdCorsConfigTest.java
+++ b/src/test/java/com/argus/config/ProdCorsConfigTest.java
@@ -1,0 +1,28 @@
+package com.argus.config;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.argus.controller.HealthController;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(HealthController.class)
+@ActiveProfiles("prod")
+class ProdCorsConfigTest {
+
+    @Autowired private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("Prod profile does not expose the dev-only localhost origin")
+    void prodProfile_doesNotAllowFrontendDevServerOrigin() throws Exception {
+        mockMvc.perform(get("/api/v1/health").header("Origin", "http://localhost:5173"))
+                .andExpect(status().isOk())
+                .andExpect(header().doesNotExist("Access-Control-Allow-Origin"));
+    }
+}


### PR DESCRIPTION
## Summary

Configure Spring application profiles for local and production environments, and add dev-only CORS support for the frontend dev server. Closes #7 

## Type of Change

- [x] `feat` — New feature

## What Changed

Implemented ARG-006 by separating shared and profile-specific backend configuration and wiring local CORS behavior for frontend development.

Key changes:
- Split Spring config into shared `application.yml` plus dedicated `application-dev.yml` and `application-prod.yml`
- Added dev and prod polling interval settings:
  - dev: flights `60s`, incidents `30m`
  - prod: flights `15s`, incidents `15m`
- Kept local database and Flyway settings under the `dev` profile
- Kept env-driven database configuration under the `prod` profile
- Added dev-only CORS configuration for `http://localhost:5173`
- Added tests verifying:
  - dev allows `http://localhost:5173`
  - dev rejects unconfigured origins
  - prod does not expose the dev-only localhost CORS rule
- Updated project documentation for the Java 17 helper script, local dev startup flow, and profile/CORS verification steps

## Testing

- [x] Unit tests written (TDD — tests were written first)
- [x] Integration tests written/updated
- [x] All existing tests pass (`./mvnw test` / `npm test`)
- [x] Coverage meets threshold (>80% backend / >70% frontend)
- [x] Manual verification completed

Manual verification:
- Started local database with `docker compose up -d db`
- Ran backend with:
  - `source ./scripts/use-java17.sh`
  - `export SPRING_PROFILES_ACTIVE=dev`
  - `./mvnw spring-boot:run`
- Verified:
  - `http://localhost:8080/swagger-ui.html`
  - `http://localhost:8080/api-docs`
  - `http://localhost:8080/api/v1/health`
- Verified CORS:
  - `Origin: http://localhost:5173` returns `200` with `Access-Control-Allow-Origin`
  - `Origin: http://localhost:3000` returns `403 Invalid CORS request`

## Screenshots

N/A

## Checklist

- [x] Code follows project conventions
- [x] Commit messages follow conventional commits format
- [x] No secrets or credentials committed
- [x] CHANGELOG.md updated (if user-facing change)
- [ ] Swagger/OpenAPI docs updated (if API change)